### PR TITLE
Implement PokemonEnv dependency injection

### DIFF
--- a/src/env/pokemon_env.py
+++ b/src/env/pokemon_env.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Tuple
 
+import numpy as np
+
 import gymnasium as gym
 
 
@@ -12,9 +14,20 @@ class PokemonEnv(gym.Env):
 
     metadata = {"render_modes": [None]}
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        opponent_player: Any,
+        state_observer: Any,
+        action_helper: Any,
+        *,
+        seed: int | None = None,
+        **kwargs: Any,
+    ) -> None:
         super().__init__()
-        # TODO: store passed arguments as needed
+        self.opponent_player = opponent_player
+        self.state_observer = state_observer
+        self.action_helper = action_helper
+        self.rng = np.random.default_rng(seed)
 
     def reset(self, *, seed: int | None = None, options: dict | None = None) -> Tuple[Any, dict]:
         """Reset the environment and return the initial observation and info."""

--- a/src/environments/__init__.py
+++ b/src/environments/__init__.py
@@ -1,0 +1,3 @@
+from src.env import pokemon_env
+
+__all__ = ["pokemon_env"]


### PR DESCRIPTION
## Summary
- add `src/environments` package for backward-compatible imports
- allow injecting opponent player, state observer and action helper into `PokemonEnv`
- add internal RNG initialized with seed

## Testing
- `pytest -q test/PokemonEnv_smoketest.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683e4aaef72c83308c79a1bf1936f193