### PR TITLE
Add basic pytest configuration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -q --cov=yourpkg
+addopts = -q
 testpaths = test
 markers =
     slow: 長時間かかるテスト


### PR DESCRIPTION
## Summary
- clean up pytest.ini
- drop unused coverage flags

## Testing
- `pytest -q` *(fails: pyenv can't find Python 3.12.9)*

------
https://chatgpt.com/codex/tasks/task_e_683e6517215083309119e2d15f160bae