### PR TITLE
Fix gen9ou team handling

### DIFF
--- a/src/env/pokemon_env.py
+++ b/src/env/pokemon_env.py
@@ -63,6 +63,8 @@ class PokemonEnv(gym.Env):
         # 対戦用のプレイヤーは初回のみ生成し、2 回目以降はリセットする。
         if not hasattr(self, "_env_player"):
 
+            from pathlib import Path
+
             class EnvPlayer(Player):
                 """Simple player used internally by the environment."""
 
@@ -70,9 +72,16 @@ class PokemonEnv(gym.Env):
                     # reset 直後はランダム行動としておく。実際の行動は step で決定する。
                     return self.choose_random_move(battle)
 
+            team_path = Path(__file__).resolve().parents[2] / "config" / "my_team.txt"
+            try:
+                team = team_path.read_text()
+            except OSError:  # pragma: no cover - デバッグ用
+                team = None
+
             self._env_player = EnvPlayer(
                 battle_format="gen9ou",
                 server_configuration=LocalhostServerConfiguration,
+                team=team,
             )
         else:
             # 既存プレイヤーのバトル履歴をクリア

--- a/test/test_pokemon_env_showdown.py
+++ b/test/test_pokemon_env_showdown.py
@@ -32,9 +32,13 @@ def test_connect_local_showdown_turn1():
         def choose_move(self, battle):
             return self.choose_random_move(battle)
 
+    team_path = ROOT / "config" / "my_team.txt"
+    team_str = team_path.read_text()
+
     opponent = RandomOpponent(
         battle_format="gen9ou",
         server_configuration=LocalhostServerConfiguration,
+        team=team_str,
     )
 
     env = PokemonEnv(opponent, TurnObserver(), DummyActionHelper())


### PR DESCRIPTION
## Summary
- load team from `config/my_team.txt` when creating env player
- provide same team to dummy opponent in showdown test

## Testing
- `pytest -q`
- `pytest -q test/test_pokemon_env_showdown.py -k test_connect_local_showdown_turn1`

------
https://chatgpt.com/codex/tasks/task_e_683e9a4a65548330b1b394dbcb908e4b