### PR TITLE
Implement battle result JSON output

### DIFF
--- a/run_battle.py
+++ b/run_battle.py
@@ -1,14 +1,15 @@
-"""Run a single battle between two :class:`RandomPlayer` instances."""
+"""Run a single battle and return the result as JSON serialisable data."""
 
 from __future__ import annotations
 
 import asyncio
+import json
 
 from poke_env.player.random_player import RandomPlayer
 from poke_env.ps_client.server_configuration import LocalhostServerConfiguration
 
 
-async def main() -> None:
+async def main() -> dict:
     player_1 = RandomPlayer(
         battle_format="gen9randombattle",
         server_configuration=LocalhostServerConfiguration,
@@ -23,9 +24,13 @@ async def main() -> None:
         player_2.accept_challenges(player_1.username, n_challenges=1),
     )
 
-    result = "Win" if player_1.n_won_battles == 1 else "Loss"
-    print(result)
+    winner = "p1" if player_1.n_won_battles == 1 else "p2"
+    battle = next(iter(player_1.battles.values()), None)
+    turns = getattr(battle, "turn", 0)
+
+    return {"winner": winner, "turns": turns}
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    result = asyncio.run(main())
+    print(json.dumps(result, ensure_ascii=False))

--- a/test/test_run_battle.py
+++ b/test/test_run_battle.py
@@ -1,0 +1,13 @@
+import asyncio
+import json
+import pytest
+
+pytest.importorskip("poke_env")
+
+from run_battle import main
+
+@pytest.mark.asyncio
+async def test_run_battle_result():
+    result = await main()
+    assert result["turns"] > 0
+    assert result["winner"] in {"p1", "p2"}


### PR DESCRIPTION
## Summary
- return winner and turn count from `run_battle.py`
- print JSON when executed as a script
- add a pytest that checks the turn count is positive

## Testing
- `pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_683f891020ac83309c2f3bbc93d42c08