### PR TITLE
Use MySimplePlayer for local battle

### DIFF
--- a/test/run_battle.py
+++ b/test/run_battle.py
@@ -4,15 +4,31 @@ from __future__ import annotations
 
 import asyncio
 import json
+from pathlib import Path
 
 from poke_env.player.random_player import RandomPlayer
 from poke_env.ps_client.server_configuration import LocalhostServerConfiguration
 
+# ``MySimplePlayer`` is our basic player defined in ``src.agents``. It selects
+# actions randomly from the set of valid ones while printing some debug
+# information. We use it for ``player_1`` in this script.
+from src.agents.my_simple_player import MySimplePlayer
+
 
 async def main() -> dict:
-    player_1 = RandomPlayer(
+    # Player1 は ``MySimplePlayer`` を利用する。デバッグ用に手持ちチームの
+    # 読み込みを試みるが、存在しなければ ``None`` を渡してランダムチームを
+    # 使用する。
+    team_file = Path(__file__).resolve().parents[1] / "config" / "my_team.txt"
+    try:
+        team_text = team_file.read_text()
+    except OSError:
+        team_text = None
+
+    player_1 = MySimplePlayer(
         battle_format="gen9randombattle",
         server_configuration=LocalhostServerConfiguration,
+        team=team_text,
     )
     player_2 = RandomPlayer(
         battle_format="gen9randombattle",


### PR DESCRIPTION
## Summary
- extend `run_battle.py` to use `MySimplePlayer` for Player1

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'poke_env')*
- `python test/run_battle.py` *(fails: ModuleNotFoundError: No module named 'poke_env')*

------
https://chatgpt.com/codex/tasks/task_e_683fad5ab72083308dac032d7ac77ded