### PR TITLE
Add multi-battle mode

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ typing_extensions==4.13.2
 tzdata==2025.2
 urllib3==2.4.0
 websockets==15.0.1
+tqdm==4.66.2


### PR DESCRIPTION
## Summary
- support running several matches in *run_battle.py*
- add `tqdm` to requirements

## Testing
- `pytest -q`
- `python test/run_battle.py --n 1` *(fails: ModuleNotFoundError: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_683fdfc4ccd48330b237550ecb8501db