### PR TITLE
Implement M4 step 8 test script

### DIFF
--- a/test/test_start_battle.py
+++ b/test/test_start_battle.py
@@ -27,7 +27,7 @@ class DummyActionHelper:
     pass
 
 
-async def main() -> None:
+async def _run() -> None:
     opponent = MySimplePlayer(battle_format="gen9randombattle")
     env = PokemonEnv(
         opponent_player=opponent,
@@ -40,5 +40,10 @@ async def main() -> None:
     env.close()
 
 
+def main() -> None:
+    """Entry point for manual testing."""
+    asyncio.run(_run())
+
+
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()


### PR DESCRIPTION
## Summary
- adjust `test_start_battle.py` so it exposes a synchronous `main()` wrapper
- this allows launching it via `python test_test_env.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6840ddbeac988330ab1271390136be73