### PR TITLE
Implement M4 step 9 skeleton

### DIFF
--- a/src/env/pokemon_env.py
+++ b/src/env/pokemon_env.py
@@ -129,9 +129,10 @@ class PokemonEnv(gym.Env):
 
     def step(self, action: Any) -> Tuple[Any, float, bool, bool, dict]:
         """Take a step in the environment using the given action."""
-        observation = None  # TODO: next observation
+        # 実装予定箇所。現段階ではダミー値を返すだけとする。
+        observation = self.observation_space.sample()
         reward: float = 0.0
-        terminated: bool = True
+        terminated: bool = False
         truncated: bool = False
         info: dict = {}
         return observation, reward, terminated, truncated, info

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -39,3 +39,17 @@ def test_observation_space_contains():
     )
     dummy_state = np.zeros(dim, dtype=np.float32)
     assert env.observation_space.contains(dummy_state)
+
+
+def test_step_returns_tuple():
+    """`step` が 5 要素タプルを返すことを確認"""
+    dim = 5
+    env = PokemonEnv(
+        opponent_player=DummyOpponent(),
+        state_observer=DummyObserver(dim),
+        action_helper=DummyActionHelper(),
+    )
+    action = env.action_space.sample()
+    result = env.step(action)
+    assert isinstance(result, tuple)
+    assert len(result) == 5

--- a/test/test_start_battle.py
+++ b/test/test_start_battle.py
@@ -47,6 +47,10 @@ async def _run() -> None:
     )
     obs, info = env.reset()
     print("reset returned", info)
+    # step が例外なく 5 要素タプルを返すか簡易チェック
+    action = env.action_space.sample()
+    result = env.step(action)
+    print("step returned", result)
     await asyncio.sleep(1)
     env.close()
 

--- a/test_test_env.py
+++ b/test_test_env.py
@@ -1,4 +1,14 @@
-from test.test_start_battle import main
+"""Utility script to run test/test_start_battle.py directly."""
+
+import sys
+from pathlib import Path
+
+# Add the test directory to the path so we can import the module
+TEST_DIR = Path(__file__).resolve().parent / "test"
+if str(TEST_DIR) not in sys.path:
+    sys.path.insert(0, str(TEST_DIR))
+
+from test_start_battle import main
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- implement dummy `step` method returning observation and 5-element tuple
- extend environment tests to cover `step`
- update manual test script to exercise `step`
- fix helper script for launching manual test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `python test_test_env.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6840ef4a62488330a386b29d68914d91