### PR TITLE
Implement action queue in PokemonEnv

### DIFF
--- a/test/test_start_battle.py
+++ b/test/test_start_battle.py
@@ -1,6 +1,12 @@
+"""Manual test for the action queue behaviour."""
+
+from __future__ import annotations
+
 import asyncio
 import sys
 from pathlib import Path
+from typing import Any
+
 import numpy as np
 
 
@@ -10,17 +16,8 @@ if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
 from src.env.pokemon_env import PokemonEnv
-from src.agents.my_simple_player import MySimplePlayer
 
-#------------------チームファイルを読み込み-----------------
-TEAM_FILE = ROOT_DIR / "config" / "my_team.txt"
-try:
-    TEAM = TEAM_FILE.read_text()
-except OSError:
-    TEAM = None
-    print("[DBG]team open error")
-    
-    
+
 class DummyObserver:
     def __init__(self, dim: int) -> None:
         self.dim = dim
@@ -28,37 +25,39 @@ class DummyObserver:
     def get_observation_dimension(self) -> int:
         return self.dim
 
-    def observe(self, battle) -> np.ndarray:
+    def observe(self, battle: Any) -> np.ndarray:  # pragma: no cover - simple stub
         return np.zeros(self.dim, dtype=np.float32)
 
 
 class DummyActionHelper:
-    pass
+    def action_index_to_order(self, player: Any, battle: Any, idx: int) -> str:
+        """Return a simple string so that the test is self contained."""
+        return f"order_{idx}"
 
 
 async def _run() -> None:
-
-
-    opponent = MySimplePlayer(battle_format="gen9ou",team=TEAM)
     env = PokemonEnv(
-        opponent_player=opponent,
-        state_observer=DummyObserver(5),
+        opponent_player=object(),
+        state_observer=DummyObserver(1),
         action_helper=DummyActionHelper(),
     )
-    obs, info = env.reset()
-    print("reset returned", info)
-    # step が例外なく 5 要素タプルを返すか簡易チェック
-    action = env.action_space.sample()
-    result = env.step(action)
-    print("step returned", result)
-    await asyncio.sleep(1)
-    env.close()
+
+    class EnvPlayer:
+        async def choose_move(self, battle: Any) -> str:
+            idx = await env._action_queue.get()
+            return env.action_helper.action_index_to_order(self, battle, idx)
+
+    env._env_player = EnvPlayer()
+
+    env._action_queue.put_nowait(5)
+    order = await env._env_player.choose_move(None)
+    print("choose_move returned", order)
 
 
 def main() -> None:
-    """Entry point for manual testing."""
     asyncio.run(_run())
 
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- introduce an asyncio queue to PokemonEnv
- use queue in EnvPlayer.choose_move
- enqueue actions in `step`
- update manual start-battle test to exercise queue

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `python test_test_env.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6840f384553483309bf6c412c82256b7