### PR TITLE
Implement reward calculation utility

### DIFF
--- a/src/env/pokemon_env.py
+++ b/src/env/pokemon_env.py
@@ -148,6 +148,19 @@ class PokemonEnv(gym.Env):
         info: dict = {}
         return observation, reward, terminated, truncated, info
 
+    # Step11: 報酬計算ユーティリティ
+    def _calc_reward(self, battle: Any) -> float:
+        """Return +1 if the battle is won, -1 if lost, otherwise 0."""
+
+        # battle.finished はバトルが終了したかどうかを示す poke-env の属性
+        if not getattr(battle, "finished", False):
+            return 0.0
+
+        # battle.won が True なら勝利、False なら敗北とみなす
+        if getattr(battle, "won", False):
+            return 1.0
+        return -1.0
+
     def render(self) -> None:
         """Render the environment if applicable."""
         return None

--- a/test/test_reward.py
+++ b/test/test_reward.py
@@ -1,0 +1,61 @@
+import sys
+from pathlib import Path
+import numpy as np
+
+# Ensure src can be imported
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from src.env.pokemon_env import PokemonEnv
+
+
+class DummyObserver:
+    def __init__(self, dim: int) -> None:
+        self.dim = dim
+
+    def get_observation_dimension(self) -> int:
+        return self.dim
+
+    def observe(self, battle) -> np.ndarray:
+        return np.zeros(self.dim, dtype=np.float32)
+
+
+class DummyActionHelper:
+    pass
+
+
+class DummyOpponent:
+    pass
+
+
+class DummyBattle:
+    def __init__(self, finished: bool, won: bool) -> None:
+        self.finished = finished
+        self.won = won
+
+
+def _make_env() -> PokemonEnv:
+    return PokemonEnv(
+        opponent_player=DummyOpponent(),
+        state_observer=DummyObserver(1),
+        action_helper=DummyActionHelper(),
+    )
+
+
+def test_calc_reward_win():
+    env = _make_env()
+    battle = DummyBattle(finished=True, won=True)
+    assert env._calc_reward(battle) == 1.0
+
+
+def test_calc_reward_loss():
+    env = _make_env()
+    battle = DummyBattle(finished=True, won=False)
+    assert env._calc_reward(battle) == -1.0
+
+
+def test_calc_reward_ongoing():
+    env = _make_env()
+    battle = DummyBattle(finished=False, won=False)
+    assert env._calc_reward(battle) == 0.0


### PR DESCRIPTION
## Summary
- implement `_calc_reward` in `PokemonEnv`
- add tests for reward calculation logic

## Testing
- `pip install -r requirements.txt` *(fails: Could not install packages)*
- `pytest -q` *(fails: ModuleNotFoundError for numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6840f715266883309222dd998e110ae9