### PR TITLE
Update PokemonEnv spec with request flow

### DIFF
--- a/docs/AI-design/PokemonEnv_Specification.md
+++ b/docs/AI-design/PokemonEnv_Specification.md
@@ -13,7 +13,7 @@
 | 使用ライブラリ | `poke_env` の `Player` と `ServerConfiguration` |
 | 通信プロトコル | Pokémon Showdown テキストコマンド (`/team`, `/choose move 1`, など) |
 | 対戦開始 | `EnvPlayer.play_against(opponent, n_battles=1)` |
-| メッセージフロー | 1. 両プレイヤーが `/team` 送信<br>2. 各ターン開始時にサーバーが `request` JSON を送信<br>3. プレイヤーが `/choose …` を返信<br>4. サーバーが結果をブロードキャスト |
+| メッセージフロー | 1. 両プレイヤーが `/team` 送信<br>2. サーバーが `request` JSON を送信してプレイヤーに行動選択を要求<br>3. プレイヤーが `/choose …` を返信<br>4. サーバーが結果をブロードキャスト |
 
 ---
 
@@ -24,9 +24,11 @@
 * 手順  
   1. `reset()` で `play_against` を呼び、裏で非同期タスクが起動  
   2. `step(action)` は行動インデックスを **BattleOrder** に変換し送信  
-  3. 各ターンでサーバーから `request` を含むメッセージを受信すると `poke_env` 内の `Battle` オブジェクトが更新される
+  3. サーバーから `request` を含むメッセージを受信すると `poke_env` 内の `Battle` オブジェクトが更新される
   4. `PokemonEnv` はこの更新を検知して観測ベクトルを生成
-
+* 注意
+ * `request` を含むメッセージは必ずしも順番通りには届かない(rqid=n+1のメッセージがrqid=nのメッセージの後に届く場合がある)ので最新のrqidに反応する必要がある
+ * 1ターンに複数の`request` を含むメッセージが来ることがある(交代選択が必要な場合:(forceSwitch=True))
 ---
 
 ## 4. 観測（状態）空間

--- a/docs/AI-design/PokemonEnv_Specification.md
+++ b/docs/AI-design/PokemonEnv_Specification.md
@@ -13,7 +13,7 @@
 | 使用ライブラリ | `poke_env` の `Player` と `ServerConfiguration` |
 | 通信プロトコル | Pokémon Showdown テキストコマンド (`/team`, `/choose move 1`, など) |
 | 対戦開始 | `EnvPlayer.play_against(opponent, n_battles=1)` |
-| メッセージフロー | 1. 両プレイヤーが `/team` 送信<br>2. 各ターンで `/choose …` を送信<br>3. サーバーが結果をブロードキャスト |
+| メッセージフロー | 1. 両プレイヤーが `/team` 送信<br>2. 各ターン開始時にサーバーが `request` JSON を送信<br>3. プレイヤーが `/choose …` を返信<br>4. サーバーが結果をブロードキャスト |
 
 ---
 
@@ -24,7 +24,8 @@
 * 手順  
   1. `reset()` で `play_against` を呼び、裏で非同期タスクが起動  
   2. `step(action)` は行動インデックスを **BattleOrder** に変換し送信  
-  3. サーバー応答で `Battle` オブジェクトが更新されるまで待機 → 観測生成  
+  3. 各ターンでサーバーから `request` を含むメッセージを受信すると `poke_env` 内の `Battle` オブジェクトが更新される
+  4. `PokemonEnv` はこの更新を検知して観測ベクトルを生成
 
 ---
 

--- a/maple_structure.md
+++ b/maple_structure.md
@@ -13,7 +13,8 @@
 ├── docs
 │   └── AI-design
 │       ├── M2
-│       └── M4
+│       ├── M4
+│       └── PokemonEnv_Specification.md
 ├── maple_structure.md
 ├── pokemon-showdown
 │   ├── ARCHITECTURE.md
@@ -59,6 +60,7 @@
 │   ├── databases
 │   │   ├── chat-plugins.db
 │   │   ├── migrations
+│   │   ├── offline-pms.db
 │   │   └── schemas
 │   ├── dist
 │   │   ├── config
@@ -542,6 +544,7 @@
 └── test
     ├── __pycache__
     │   ├── run_battle.cpython-312.pyc
+    │   ├── test_env.cpython-312-pytest-8.4.0.pyc
     │   ├── test_pokemon_env_showdown.cpython-312-pytest-8.4.0.pyc
     │   ├── test_pokemon_env_step2_4.cpython-312-pytest-8.4.0.pyc
     │   ├── test_pokemon_env_step5.cpython-312-pytest-8.4.0.pyc
@@ -549,4 +552,4 @@
     ├── run_battle.py
     └── simple_agent.py
 
-390 directories, 160 files
+390 directories, 163 files


### PR DESCRIPTION
## Summary
- document that the showdown server sends `request` JSON messages
- clarify how these messages update the Battle object and trigger observation generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68414de933248330988d69478d9d2d76