### PR TITLE
Remove poke-env request hook from PokemonEnv

### DIFF
--- a/src/env/pokemon_env.py
+++ b/src/env/pokemon_env.py
@@ -95,11 +95,9 @@ class PokemonEnv(gym.Env):
                 team=team,
                 log_level=logging.DEBUG,
             )
-            self._install_request_hook()
         else:
             # 既存プレイヤーのバトル履歴をクリア
             self._env_player.reset_battles()
-            self._install_request_hook()
 
         if hasattr(self.opponent_player, "reset_battles"):
             self.opponent_player.reset_battles()
@@ -220,67 +218,6 @@ class PokemonEnv(gym.Env):
             truncated = True
         return terminated, truncated
 
-    def _install_request_hook(self) -> None:
-        """Hook into poke-env client to parse incoming request messages."""
-        import json
-
-        client = getattr(self._env_player, "ps_client", None)
-        if client is None:
-            return
-
-        original = getattr(client, "_handle_message", None)
-
-        if original is None:
-            return
-
-        def _hook(message: str, *args: Any, **kwargs: Any) -> Any:
-            current_tag: str | None = None
-            request = None
-            battle = None
-
-            for line in message.splitlines():
-                if not line:
-                    continue
-
-                if line.startswith(">"):
-                    current_tag = line[1:].split("|", 1)[0]
-
-                if "|request|" not in line:
-                    continue
-
-                line = line.lstrip(">")
-                parts = line.split("|", 2)
-                if len(parts) < 3:
-                    continue
-
-                tag = parts[0] or current_tag
-
-                try:
-                    request = json.loads(parts[2])
-                except Exception:
-                    continue
-
-                if tag:
-                    battle = self._env_player.battles.get(tag)
-                if battle is None and current_tag:
-                    battle = self._env_player.battles.get(current_tag)
-                if battle is None:
-                    battle = next(iter(self._env_player.battles.values()), None)
-                break
-
-            if battle is not None and request is not None:
-                setattr(battle, "request", request)
-                self._handle_team_preview(battle)
-
-            result = original(message, *args, **kwargs)
-
-            if battle is not None and request is not None:
-                setattr(battle, "request", request)
-                self._handle_team_preview(battle)
-
-            return result
-
-        client._handle_message = _hook
 
     def _handle_team_preview(self, battle: Any) -> None:
         """Send team selection when a team preview request is present."""


### PR DESCRIPTION
## Summary
- drop `_install_request_hook` and its usage
- rely on poke-env's public callbacks for requests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842fbcd964883309f20c4196cebaf79