### PR TITLE
Fix queued player awaiting battle initialization

### DIFF
--- a/src/agents/queued_random_player.py
+++ b/src/agents/queued_random_player.py
@@ -23,9 +23,41 @@ class QueuedRandomPlayer(Player):
     ) -> None:
         super().__init__(**kwargs)
         self._rng = np.random.default_rng(seed)
+        self._battle_ready: dict[str, asyncio.Event] = {}
+
+    async def _create_battle(self, *args: Any, **kwargs: Any) -> Any:
+        """Wrap ``Player._create_battle`` and signal completion."""
+        battle_tag = None
+        if args:
+            battle_tag = args[0]
+        if 'battle_tag' in kwargs:
+            battle_tag = kwargs['battle_tag']
+
+        event = asyncio.Event()
+        if battle_tag is not None:
+            self._battle_ready[battle_tag] = event
+
+        battle = await super()._create_battle(*args, **kwargs)
+
+        if battle_tag is None and hasattr(battle, "battle_tag"):
+            battle_tag = getattr(battle, "battle_tag")
+            self._battle_ready[battle_tag] = event
+
+        event.set()
+        return battle
 
     def teampreview(self, battle: Battle) -> str:  # pragma: no cover - runtime
         """Randomly select three Pokémon from 1–6."""
+        event = self._battle_ready.get(battle.battle_tag)
+        if event is not None and not event.is_set():
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                asyncio.run(event.wait())
+            else:
+                fut = asyncio.run_coroutine_threadsafe(event.wait(), loop)
+                fut.result()
+
         indices = self._rng.choice(range(1, 7), size=3, replace=False)
         order = "/team " + "".join(str(i) for i in indices)
         print(f'[DBG:queued_random_player.py] order = {order}')
@@ -34,7 +66,10 @@ class QueuedRandomPlayer(Player):
 
     async def choose_move(self, battle) -> Any:  # pragma: no cover - runtime behaviour
         """ターンごとの行動を決定する。"""
-        await asyncio.sleep(2)
+        event = self._battle_ready.get(battle.battle_tag)
+        if event is not None and not event.is_set():
+            await event.wait()
+
         # チームプレビュー判定
         print(battle.teampreview)
         if battle.teampreview:


### PR DESCRIPTION
## Summary
- ensure battle creation finishes before player acts
- guard `choose_move` and `teampreview` with battle creation events

## Testing
- `pytest -vv` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68450dda29008330a448db3e63c65cd6