### PR TITLE
Update battle processing to send action mapping

### DIFF
--- a/scripts/step_skeleton_demo.py
+++ b/scripts/step_skeleton_demo.py
@@ -34,7 +34,7 @@ class DummyOpponent:
 
 
 class RandomAgent(MapleAgent):
-    def select_action(self, observation: object) -> int:
+    def select_action(self, observation: object, action_mapping: object) -> int:
         return self.env.action_space.sample()
 
 
@@ -46,7 +46,7 @@ def main() -> None:
     )
     agent = RandomAgent(env)
 
-    action = agent.select_action(None)
+    action = agent.select_action(None, {})
     result = env.step(action)
     print("Step result:", result)
 

--- a/src/agents/MapleAgent.py
+++ b/src/agents/MapleAgent.py
@@ -18,7 +18,16 @@ class MapleAgent:
         """Hook for team preview phase. Override in subclasses."""
         pass
 
-    def select_action(self, observation: Any) -> int:
-        """Return an action index given an observation."""
+    def select_action(self, observation: Any, action_mapping: Any) -> int:
+        """Return an action index given the current observation and actions.
+
+        Parameters
+        ----------
+        observation : Any
+            Observation vector generated from :class:`PokemonEnv`.
+        action_mapping : Any
+            Mapping of available action indices as provided by
+            ``action_helper.get_available_actions_with_details``.
+        """
         raise NotImplementedError
 

--- a/src/env/pokemon_env.py
+++ b/src/env/pokemon_env.py
@@ -64,11 +64,22 @@ class PokemonEnv(gym.Env):
         self._agent = agent
 
     def process_battle(self, battle: Any) -> int:
-        """Create an observation from ``battle`` and query the agent."""
+        """Create an observation and available action mapping for ``battle``.
+
+        The resulting state vector and action mapping are sent to the registered
+        :class:`MapleAgent` which returns an action index.
+        """
         if self._agent is None:
             raise RuntimeError("Agent not registered")
+
         observation = self.state_observer.observe(battle)
-        action_idx = self._agent.select_action(observation)
+
+        # battle 情報から利用可能な行動マッピングを生成
+        _, action_mapping = self.action_helper.get_available_actions_with_details(
+            battle
+        )
+
+        action_idx = self._agent.select_action(observation, action_mapping)
         return int(action_idx)
 
     def reset(self, *, seed: int | None = None, options: dict | None = None) -> Tuple[Any, dict]:

--- a/test/run_battle.py
+++ b/test/run_battle.py
@@ -26,7 +26,7 @@ from src.action import action_helper
 class RandomAgent(MapleAgent):
     """Simple agent that selects random actions."""
 
-    def select_action(self, observation: object) -> int:
+    def select_action(self, observation: object, action_mapping: object) -> int:
         return self.env.action_space.sample()
 from poke_env.ps_client.server_configuration import LocalhostServerConfiguration
 
@@ -56,7 +56,8 @@ def run_single_battle() -> dict:
     MAX_STEPS = 100
     battle = next(iter(env._env_player.battles.values()))
     for _ in range(MAX_STEPS):
-        action = agent.select_action(observation)
+        _, mapping = action_helper.get_available_actions_with_details(battle)
+        action = agent.select_action(observation, mapping)
         observation, reward, terminated, truncated, info = env.step(action)
         time.sleep(0.1)
         battle = next(iter(env._env_player.battles.values()))


### PR DESCRIPTION
## Summary
- update `PokemonEnv.process_battle` to create action mapping via `action_helper.get_available_actions_with_details` and send it to the agent
- extend `MapleAgent.select_action` to receive the mapping
- adapt demo script and tests to the new interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483bd75124833084f8fc9d87e8932c