### PR TITLE
Implement random stepping in MapleAgent

### DIFF
--- a/scripts/step_skeleton_demo.py
+++ b/scripts/step_skeleton_demo.py
@@ -33,9 +33,6 @@ class DummyOpponent:
         pass
 
 
-class RandomAgent(MapleAgent):
-    def select_action(self, observation: object, action_mapping: object) -> int:
-        return self.env.action_space.sample()
 
 
 def main() -> None:
@@ -44,11 +41,10 @@ def main() -> None:
         state_observer=DummyObserver(5),
         action_helper=DummyActionHelper(),
     )
-    agent = RandomAgent(env)
+    agent = MapleAgent(env)
 
-    action = agent.select_action(None, {})
-    result = env.step(action)
-    print("Step result:", result)
+    agent.select_action(None, {})
+    print("Step executed")
 
 
 if __name__ == "__main__":

--- a/src/agents/MapleAgent.py
+++ b/src/agents/MapleAgent.py
@@ -19,7 +19,7 @@ class MapleAgent:
         pass
 
     def select_action(self, observation: Any, action_mapping: Any) -> int:
-        """Return an action index given the current observation and actions.
+        """Select a random valid action and execute ``env.step``.
 
         Parameters
         ----------
@@ -29,5 +29,18 @@ class MapleAgent:
             Mapping of available action indices as provided by
             ``action_helper.get_available_actions_with_details``.
         """
-        raise NotImplementedError
+
+        # ``action_mapping`` は ``action_helper.get_available_actions_with_details``
+        # から得られる辞書で、キーに選択可能な行動 index が含まれている。マッピングが
+        # 空の場合は ``action_space`` 全体からサンプリングする。
+        if action_mapping:
+            action_idx = int(self.env.rng.choice(list(action_mapping.keys())))
+        else:
+            action_idx = int(self.env.action_space.sample())
+
+        # ランダムに選んだ行動を即座に環境へ反映させる
+        # ``step`` の戻り値はここでは利用しない
+        self.env.step(action_idx)
+
+        return action_idx
 

--- a/test/run_battle.py
+++ b/test/run_battle.py
@@ -21,13 +21,6 @@ from src.agents.rule_based_player import RuleBasedPlayer
 from src.env.pokemon_env import PokemonEnv
 from src.state.state_observer import StateObserver
 from src.action import action_helper
-
-
-class RandomAgent(MapleAgent):
-    """Simple agent that selects random actions."""
-
-    def select_action(self, observation: object, action_mapping: object) -> int:
-        return self.env.action_space.sample()
 from poke_env.ps_client.server_configuration import LocalhostServerConfiguration
 
 TEAM_FILE = ROOT_DIR / "config" / "my_team.txt"
@@ -48,7 +41,7 @@ def run_single_battle() -> dict:
 
     observer = StateObserver(str(ROOT_DIR / "config" / "state_spec.yml"))
     env = PokemonEnv(opponent_player=opponent, state_observer=observer, action_helper=action_helper)
-    agent = RandomAgent(env)
+    agent = MapleAgent(env)
 
     observation, info = env.reset()
 
@@ -58,7 +51,7 @@ def run_single_battle() -> dict:
     for _ in range(MAX_STEPS):
         _, mapping = action_helper.get_available_actions_with_details(battle)
         action = agent.select_action(observation, mapping)
-        observation, reward, terminated, truncated, info = env.step(action)
+        # `select_action` internally calls `env.step`, so the returned index is only for reference
         time.sleep(0.1)
         battle = next(iter(env._env_player.battles.values()))
         if battle.finished:


### PR DESCRIPTION
## Summary
- make `MapleAgent.select_action()` choose a random available action and call `env.step`
- adjust example scripts to use new behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68483eb6466c83308a60315c73d6c5a4