### PR TITLE
Add step loop for MapleAgent

### DIFF
--- a/src/agents/MapleAgent.py
+++ b/src/agents/MapleAgent.py
@@ -44,3 +44,27 @@ class MapleAgent:
 
         return action_idx
 
+    def play_until_done(self, observation: Any, action_mapping: Any) -> None:
+        """Keep calling :meth:`PokemonEnv.step` until ``done`` becomes ``True``.
+
+        Parameters
+        ----------
+        observation : Any
+            Initial observation vector returned by ``env.reset``.
+        action_mapping : Any
+            Mapping of available actions corresponding to ``observation``.
+        """
+
+        done = False
+        current_obs = observation
+        current_map = action_mapping
+
+        while not done:
+            if current_map:
+                action_idx = int(self.env.rng.choice(list(current_map.keys())))
+            else:
+                action_idx = int(self.env.action_space.sample())
+
+            current_obs, current_map, _, done, _ = self.env.step(action_idx)
+
+

--- a/test/run_battle.py
+++ b/test/run_battle.py
@@ -45,17 +45,11 @@ def run_single_battle() -> dict:
 
     observation, info = env.reset()
 
-    # Run until the internal battle finishes or a safety limit is reached
-    MAX_STEPS = 100
     battle = next(iter(env._env_player.battles.values()))
-    for _ in range(MAX_STEPS):
-        _, mapping = action_helper.get_available_actions_with_details(battle)
-        action = agent.select_action(observation, mapping)
-        # `select_action` internally calls `env.step`, so the returned index is only for reference
-        time.sleep(0.1)
-        battle = next(iter(env._env_player.battles.values()))
-        if battle.finished:
-            break
+    _, mapping = action_helper.get_available_actions_with_details(battle)
+    agent.play_until_done(observation, mapping)
+
+    battle = next(iter(env._env_player.battles.values()))
 
     winner = "env" if env._env_player.n_won_battles == 1 else "opponent"
     turns = getattr(battle, "turn", 0)


### PR DESCRIPTION
## Summary
- extend `MapleAgent` with `play_until_done` to repeatedly call `env.step`
- update `test/run_battle.py` to utilise the new method

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68484a5e86a88330a4646c343a66be14