### PR TITLE
Update MapleAgent to handle teampreview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 .env
 .docs
 __pycache__/
-src\env\__pychache__\
+src/env/__pycache__/

--- a/test/run_battle.py
+++ b/test/run_battle.py
@@ -47,7 +47,7 @@ def run_single_battle() -> dict:
 
     battle = next(iter(env._env_player.battles.values()))
     _, mapping = action_helper.get_available_actions_with_details(battle)
-    agent.play_until_done(observation, mapping)
+    agent.play_until_done(observation, mapping, info)
 
     battle = next(iter(env._env_player.battles.values()))
 


### PR DESCRIPTION
## Summary
- fix `.gitignore` invalid entry
- implement default random team preview logic in `MapleAgent`
- allow `MapleAgent.play_until_done` to handle teampreview requests
- update example test script to pass info to the agent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849178e465c833092a462eb65f9860d