### PR TITLE
Implement team preview callback

### DIFF
--- a/docs/AI-design/PokemonEnv_Specification.md
+++ b/docs/AI-design/PokemonEnv_Specification.md
@@ -31,8 +31,8 @@
   3. `reset()` で `battle_against()` を呼び、対戦を開始
   4. `PokemonEnv`は`reset()`内で`EnvPlayer`からメッセージが来るのを待機
   5. `EnvPlayer`は`|teampreview|`のメッセージが届いたら`PokeonEnv`に`my_team: List`と`opp_team: List`を渡して、チーム選択を要求(この時点ではBattleオブジェクトは空である)
-  6. `PokemonEnv`は`reset()`の戻り値として`state`と`info`を`Agent`にわたす(`info`で`Agent`にteampreview要求。現時点でstateは未実装なのでダミーを渡す。)
-  7. `Agent`は`info`の情報からチーム選択が呼び出されたことを理解して、`step(teampreview(state))`を実行
+  6. `PokemonEnv`は`reset()`の戻り値として`state`と`info`を`Agent`にわたす(`info`で`Agent`にチームプレビュー要求。現時点でstateは未実装なのでダミーを渡す。)
+  7. `Agent`は`info`の情報からチーム選択が呼び出されたことを理解して、`step(choose_team(state))`を実行
   8. `PokemonEnv`はチーム選択を受け取り`EnvPlayer`に送信
   9. `EnvPlayer`はチーム選択をサーバに送信して新しい`request`を待つ
   10. `request`が発生したら`EnvPlaer`は`battle`オブジェクトを更新し、`PokemonEnv`に`battle`オブジェクトとフラグやキューを`PokemonEnv` にわたして`action`を待機する(ここで初めてbattleオブジェクトが更新)
@@ -128,7 +128,7 @@ sequenceDiagram
 
 * **遅延インポート**: `poke_env` は `reset()` 内でインポート
 * **EnvPlayer**: 行動アルゴリズムは外部エージェントに委任
-* **チームプレビュー**: `Agent.teampreview()` でチーム選択を行い `/choose team` を送信（デフォルトはランダム3匹選出）
+* **チームプレビュー**: `Agent.choose_team()` でチーム選択を行い `/choose team` を送信（デフォルトはランダム3匹選出）
 * **再利用接続**: 各エピソード開始時に `reset_battles()`
 * **step 待機処理**: `asyncio.wait_for(queue.get(), timeout)` を用いて待ち合わせ、ビジーウェイトを避ける
 * **close() 実装**: `POKE_LOOP` 上のタスクをキャンセルし、キューの `join()` 後にリソースを解放する

--- a/src/agents/MapleAgent.py
+++ b/src/agents/MapleAgent.py
@@ -14,21 +14,17 @@ class MapleAgent:
         if hasattr(self.env, "register_agent"):
             self.env.register_agent(self)
 
-    def teampreview(self, battle: Any) -> str:
+    def choose_team(self, observation: Any) -> str:
         """Return a team selection string for the team preview phase.
 
-        This default implementation randomly selects three Pokémon from
-        ``battle.team`` and returns a ``"/team"`` command string.  Subclasses
-        can override this method to implement a custom selection strategy.
+        The base implementation ignores ``observation`` and simply selects
+        three random Pokémon assuming a team size of six.  Subclasses can
+        override this method to implement a custom selection strategy.
         """
-        
+
         print("チームプレビューリクエスト確認")
 
-        team_size = len(getattr(battle, "team", [])) if battle else 0
-        if team_size <= 0:
-            
-            return "/team 123"  # フォールバック
-
+        team_size = 6
         num_to_select = min(3, team_size)
         indices = self.env.rng.choice(team_size, size=num_to_select, replace=False)
         indices = sorted(int(i) + 1 for i in indices)
@@ -70,8 +66,8 @@ class MapleAgent:
         action_mapping : Any
             Mapping of available actions corresponding to ``observation``.
         ``info`` may include ``"request_teampreview"``.  When this flag is
-        present and ``True``, a team selection is performed automatically before
-        entering the main loop.
+        present and ``True``, a team selection is performed automatically by
+        calling :meth:`choose_team` before entering the main loop.
 
         The selected index from :meth:`select_action` is passed to
         :meth:`PokemonEnv.step` each iteration.
@@ -82,8 +78,7 @@ class MapleAgent:
         current_map = action_mapping
 
         if info and info.get("request_teampreview"):
-            battle = info.get("battle")
-            team_order = self.teampreview(battle)
+            team_order = self.choose_team(current_obs)
             current_obs, current_map, _, done, info = self.env.step(team_order)
 
         while not done:

--- a/test/run_battle.py
+++ b/test/run_battle.py
@@ -45,9 +45,14 @@ def run_single_battle() -> dict:
 
     observation, info = env.reset()
 
-    battle = next(iter(env._env_player.battles.values()))
-    _, mapping = action_helper.get_available_actions_with_details(battle)
-    agent.play_until_done(observation, mapping)
+    if info.get("request_teampreview"):
+        team_order = agent.choose_team(observation)
+        observation, mapping, _, _, info = env.step(team_order)
+    else:
+        battle = next(iter(env._env_player.battles.values()))
+        _, mapping = action_helper.get_available_actions_with_details(battle)
+
+    agent.play_until_done(observation, mapping, info)
 
     battle = next(iter(env._env_player.battles.values()))
 


### PR DESCRIPTION
## Summary
- enable team preview interaction with EnvPlayer via `choose_team` callback
- start the battle with team selection in `run_battle.py`
- update documentation for the new method name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a40b5e3e48330a227d6dac0905900