### PR TITLE
Update backlog for M4

### DIFF
--- a/docs/AI-design/M4/M4_backlog.md
+++ b/docs/AI-design/M4/M4_backlog.md
@@ -17,28 +17,30 @@
 | 8 | 初期観測値の返却 | `StateObserver` を用いて最初の `observation` と `info` を返す | `reset()` の戻り値が `(obs, info)` 形式かつ観測空間に適合 | 観測内容をテストで確認 | StateObserver |
 | 9 | step スケルトン実装 | `step(action)` が 5 要素タプルを返す形だけ用意 | ダミー値でも呼び出し可能 | `env.step(0)` を実行し例外無し | Gymnasium 仕様 |
 |10| 非同期アクションキュー | `asyncio.Queue` を導入し `choose_move` がキューから行動を取得 | キューへインデックスを投入すると `choose_move` が対応する `BattleOrder` を返す | 単体テストでキュー処理を検証 | asyncio.Queue, action_helper |
-|11| 報酬計算関数 | 勝敗に応じて ±1 を返す `_calc_reward(battle)` を実装 | 終了時に勝利で +1, 敗北で -1, 途中は 0 | 模擬 Battle オブジェクトでテスト | poke-env Battle API |
-|12| 終了判定の追加 | `terminated`・`truncated` を判定するロジックを作成 | `battle.finished` または `turn > MAX_TURNS` でフラグが立つ | 実際に対戦を最後まで行いフラグ確認 | Battle 属性参照 |
-|13| ターン同期処理 | 行動送信後に最新 `rqid` の `request` が届くまで待機 | `rqid` が乱序でも次ターンへ正しく進む | 強制交代を含むテスト戦でターン数が正しく増加 | asyncio 待機, rqid 管理 |
-|14| step 結果生成 | 観測取得、報酬計算、終了判定をまとめて返す | `(obs, reward, terminated, truncated, info)` が正しく構築される | ランダムエージェントで 1 戦完走 | 全機能統合 |
-|15| render 実装 | ターン情報などをコンソール表示 | 任意のタイミングで `env.render()` を呼び出しても例外無し | 実行時の表示を目視 | ロギング |
-|16| close 実装 | WebSocket とスレッドを安全に閉じる | `env.close()` 後にプロセス終了してもリソースリーク無し | Python プロファイルで確認 | poke-env `stop_listening` |
-|17| ランダムエージェント | テスト用エージェントが `action_space.sample()` を返す | 範囲外のインデックスを返さない | 簡単なユニットテスト | numpy RNG |
-|18| 学習ループスクリプト | `random_rollout.py` で複数エピソードを回す雛形 | `python random_rollout.py --episodes 3` が完了 | コマンドライン引数の処理確認 | argparse, tqdm |
-|19| 進捗バー付きログ | ログを整形し `tqdm` で進捗表示 | エピソード10回実行時にバーが表示される | 実行結果を目視確認 | tqdm |
-|20| 報酬とターン数の集計 | 各エピソード終了時に報酬とターン数を記録 | 出力ログに `reward=X, turns=Y` が含まれる | スクリプト実行結果を確認 | logging |
-|21| PokemonEnv ユニットテスト | 基本 API の動作を自動テスト | `tests/test_pokemon_env.py` が全て PASS | `pytest -q` を実行 | pytest, unittest.mock |
-|22| 非同期メッセージテスト | メッセージ順不同や遅延に強いか検証 | artificial sleep を入れてもデッドロックしない | 遅延付きテストシナリオで正常終了 | asyncio, poke-env |
-|23| E2E 統合テスト | ランダムエージェント同士で 1 戦実行 | 終了フラグと報酬 ±1 を確認 | スクリプト上で対戦完了 | poke-env RandomPlayer |
-|24| 複数エピソード連続実行 | 10 エピソード連続でも安定 | 途中エラーやリークが無い | `random_rollout.py --episodes 10` を実行 | 長時間実行テスト |
-|25| ドキュメント更新 | M4 セットアップ手順をまとめる | `docs/M4_setup.md` 追加、README にリンク | Markdown のリンク切れを確認 | Markdown |
-|26| コード整形 & リファクタ | `black` と `ruff` でコードスタイル統一 | `black --check .` と `ruff .` がどちらもパス | フォーマット後にテスト実行 | black, ruff |
-|27| CI ワークフロー更新 | GitHub Actions で PokemonEnv テストを実行 | CI ジョブが Showdown サーバを起動し `pytest` を実行 | GitHub Actions の結果が緑 | GitHub Actions |
-|28| タイムアウト処理見直し | `asyncio.wait_for` で無限待機を防ぐ | 行動を送らずに放置すると TimeoutError が発生し環境がリセット | 専用テストで確認 | asyncio.wait_for |
-|29| 依存バージョン固定 | `requirements.txt` にバージョン指定を追加 | 新規環境でインストール後テストが全て PASS | `pytest -q` 実行 | pip, version pinning |
-|30| M4 完了レビュー | DoD を満たすことを総合確認 | 50 エピソード連続実行で安定、コードレビューで承認 | 実機テスト + レビュー | 総合確認 |
+|11| エピソード完走確認 | 対戦が最後まで実行できるか検証 | `python random_rollout.py --episodes 1` が完走する | ログに最終ターンが表示される | poke-env, asyncio |
+|12| 報酬計算関数 | 勝敗に応じて ±1 を返す `_calc_reward(battle)` を実装 | 終了時に勝利で +1, 敗北で -1, 途中は 0 | 模擬 Battle オブジェクトでテスト | poke-env Battle API |
+|13| 終了判定の追加 | `terminated`・`truncated` を判定するロジックを作成 | `battle.finished` または `turn > MAX_TURNS` でフラグが立つ | 実際に対戦を最後まで行いフラグ確認 | Battle 属性参照 |
+|14| ターン同期処理 | 行動送信後に最新 `rqid` の `request` が届くまで待機 | `rqid` が乱序でも次ターンへ正しく進む | 強制交代を含むテスト戦でターン数が正しく増加 | asyncio 待機, rqid 管理 |
+|15| step 結果生成 | 観測取得、報酬計算、終了判定をまとめて返す | `(obs, reward, terminated, truncated, info)` が正しく構築される | ランダムエージェントで 1 戦完走 | 全機能統合 |
+|16| render 実装 | ターン情報などをコンソール表示 | 任意のタイミングで `env.render()` を呼び出しても例外無し | 実行時の表示を目視 | ロギング |
+|17| close 実装 | WebSocket とスレッドを安全に閉じる | `env.close()` 後にプロセス終了してもリソースリーク無し | Python プロファイルで確認 | poke-env `stop_listening` |
+|18| ランダムエージェント | テスト用エージェントが `action_space.sample()` を返す | 範囲外のインデックスを返さない | 簡単なユニットテスト | numpy RNG |
+|19| 学習ループスクリプト | `random_rollout.py` で複数エピソードを回す雛形 | `python random_rollout.py --episodes 3` が完了 | コマンドライン引数の処理確認 | argparse, tqdm |
+|20| 進捗バー付きログ | ログを整形し `tqdm` で進捗表示 | エピソード10回実行時にバーが表示される | 実行結果を目視確認 | tqdm |
+|21| 報酬とターン数の集計 | 各エピソード終了時に報酬とターン数を記録 | 出力ログに `reward=X, turns=Y` が含まれる | スクリプト実行結果を確認 | logging |
+|22| PokemonEnv ユニットテスト | 基本 API の動作を自動テスト | `tests/test_pokemon_env.py` が全て PASS | `pytest -q` を実行 | pytest, unittest.mock |
+|23| 非同期メッセージテスト | メッセージ順不同や遅延に強いか検証 | artificial sleep を入れてもデッドロックしない | 遅延付きテストシナリオで正常終了 | asyncio, poke-env |
+|24| E2E 統合テスト | ランダムエージェント同士で 1 戦実行 | 終了フラグと報酬 ±1 を確認 | スクリプト上で対戦完了 | poke-env RandomPlayer |
+|25| 複数エピソード連続実行 | 10 エピソード連続でも安定 | 途中エラーやリークが無い | `random_rollout.py --episodes 10` を実行 | 長時間実行テスト |
+|26| ドキュメント更新 | M4 セットアップ手順をまとめる | `docs/M4_setup.md` 追加、README にリンク | Markdown のリンク切れを確認 | Markdown |
+|27| コード整形 & リファクタ | `black` と `ruff` でコードスタイル統一 | `black --check .` と `ruff .` がどちらもパス | フォーマット後にテスト実行 | black, ruff |
+|28| CI ワークフロー更新 | GitHub Actions で PokemonEnv テストを実行 | CI ジョブが Showdown サーバを起動し `pytest` を実行 | GitHub Actions の結果が緑 | GitHub Actions |
+|29| タイムアウト処理見直し | `asyncio.wait_for` で無限待機を防ぐ | 行動を送らずに放置すると TimeoutError が発生し環境がリセット | 専用テストで確認 | asyncio.wait_for |
+|30| 依存バージョン固定 | `requirements.txt` にバージョン指定を追加 | 新規環境でインストール後テストが全て PASS | `pytest -q` 実行 | pip, version pinning |
+|31| M4 完了レビュー | DoD を満たすことを総合確認 | 50 エピソード連続実行で安定、コードレビューで承認 | 実機テスト + レビュー | 総合確認 |
 
 > **備考**
 > - `PokemonEnv_Specification.md` のフロー図を常に参照して実装を進めること。
 > - `MAX_TURNS` 等のパラメータは `config/env_config.yml` にまとめると管理しやすい。
 > - Showdown サーバは `npx pokemon-showdown` でローカル起動しポート `8000` を利用する想定。
+> - ステップ10完了後、エピソードが最後まで完了することを確認してから報酬計算と終了判定を実装する。


### PR DESCRIPTION
## Summary
- add episode completion check after step 10
- renumber subsequent backlog items
- note the new flow in the remarks section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a5bdc23288330b520f3000e39abb9