### PR TITLE
Add SingleAgentCompatibilityWrapper

### DIFF
--- a/src/env/__init__.py
+++ b/src/env/__init__.py
@@ -1,4 +1,5 @@
 from .pokemon_env import PokemonEnv
 from .env_player import EnvPlayer
+from .wrappers import SingleAgentCompatibilityWrapper
 
-__all__ = ["PokemonEnv", "EnvPlayer"]
+__all__ = ["PokemonEnv", "EnvPlayer", "SingleAgentCompatibilityWrapper"]

--- a/src/env/wrappers.py
+++ b/src/env/wrappers.py
@@ -1,0 +1,54 @@
+"""Environment wrappers for compatibility."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import gymnasium as gym
+
+try:  # Some tests stub out gymnasium
+    GymWrapper = gym.Wrapper
+except AttributeError:  # pragma: no cover - fallback for stubs
+    GymWrapper = object
+
+from .pokemon_env import PokemonEnv
+
+
+class SingleAgentCompatibilityWrapper(GymWrapper):
+    """Wrap :class:`PokemonEnv` for single-agent Gym interface."""
+
+    def __init__(self, env: PokemonEnv) -> None:
+        if GymWrapper is not object:
+            super().__init__(env)
+        self.env: PokemonEnv = env
+        # Enable single-agent mode in the underlying environment
+        setattr(self.env, "single_agent_mode", True)
+
+    @property
+    def action_space(self) -> gym.Space:
+        return self.env.action_space[self.env.agent_ids[0]]
+
+    @property
+    def observation_space(self) -> gym.Space:
+        return self.env.observation_space[self.env.agent_ids[0]]
+
+    def reset(self, *, seed: int | None = None, options: dict | None = None):
+        observation, info = self.env.reset(seed=seed, options=options)
+        return observation, info
+
+    def step(self, action: Any):
+        return self.env.step({"player_0": action})
+
+
+def make_single_agent_env(**kwargs: Any) -> gym.Env:
+    """Return :class:`PokemonEnv` wrapped for single-agent usage."""
+
+    env = PokemonEnv(**kwargs)
+    return SingleAgentCompatibilityWrapper(env)
+
+
+if hasattr(gym, "register"):
+    gym.register(
+        "PokemonEnv-SA-v0",
+        entry_point="src.env.wrappers:make_single_agent_env",
+    )

--- a/tests/test_single_agent_wrapper.py
+++ b/tests/test_single_agent_wrapper.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root))
+
+from src.env.wrappers import SingleAgentCompatibilityWrapper
+
+
+class DummyEnv:
+    def __init__(self):
+        self.agent_ids = ("player_0", "player_1")
+        self.action_space = {"player_0": "a0", "player_1": "a1"}
+        self.observation_space = {"player_0": "o0", "player_1": "o1"}
+        self.reset = MagicMock(return_value=("obs", {}))
+        self.step = MagicMock(return_value=("obs", [0], 1.0, True, {}))
+
+
+def test_wrapper_delegates_calls():
+    env = DummyEnv()
+    wrapper = SingleAgentCompatibilityWrapper(env)
+    assert getattr(env, "single_agent_mode") is True
+    assert wrapper.action_space == "a0"
+    assert wrapper.observation_space == "o0"
+
+    obs, info = wrapper.reset()
+    env.reset.assert_called_once()
+    assert obs == "obs"
+    assert info == {}
+
+    result = wrapper.step(1)
+    env.step.assert_called_with({"player_0": 1})
+    assert result[0] == "obs"
+


### PR DESCRIPTION
## Summary
- add `SingleAgentCompatibilityWrapper` and register `PokemonEnv-SA-v0`
- export wrapper in package __init__
- test that wrapper delegates to base environment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aef146aec8330870101bab302f1fe