### PR TITLE
Enable direct execution of multi env test

### DIFF
--- a/tests/test_pokemon_env_multi.py
+++ b/tests/test_pokemon_env_multi.py
@@ -142,3 +142,9 @@ def test_pokemon_env_multi(monkeypatch):
         )
         assert isinstance(observation, dict) and "player_0" in observation
     env.close()
+
+
+if __name__ == "__main__":
+    import pytest
+
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary
- allow `tests/test_pokemon_env_multi.py` to be executed with the `python` command

## Testing
- `pytest -q tests/test_pokemon_env_multi.py`
- `python tests/test_pokemon_env_multi.py`


------
https://chatgpt.com/codex/tasks/task_e_684af6165f388330955da47deebb53ee