### PR TITLE
Add debug logs to trace hang after team selection

### DIFF
--- a/src/agents/MapleAgent.py
+++ b/src/agents/MapleAgent.py
@@ -26,7 +26,9 @@ class MapleAgent:
         num_to_select = min(3, team_size)
         indices = self.env.rng.choice(team_size, size=num_to_select, replace=False)
         indices = sorted(int(i) + 1 for i in indices)
-        return "/team " + "".join(str(i) for i in indices)
+        team_cmd = "/team " + "".join(str(i) for i in indices)
+        print(f"[DBG_STOP] MapleAgent.choose_team -> {team_cmd}")
+        return team_cmd
 
     def select_action(self, observation: Any, action_mask: Any) -> int:
         """Return a random valid action index.

--- a/src/agents/maple_agent_player.py
+++ b/src/agents/maple_agent_player.py
@@ -23,22 +23,34 @@ class MapleAgentPlayer(Player):
         self._helper = action_helper
 
     def choose_move(self, battle: Battle) -> Any:
+        print(
+            f"[DBG_STOP] MapleAgentPlayer.choose_move start tp={battle.teampreview} turn={battle.turn}"
+        )
         # battle から状態ベクトルと利用可能アクションを取得
         state = self._observer.observe(battle)
         mask, mapping = self._helper.get_available_actions(battle)
+        print(f"[DBG_STOP] MapleAgentPlayer available mapping {mapping}")
 
         # MapleAgent で行動インデックスを選択
         idx = self.maple_agent.select_action(state, mask)
 
         # インデックスを BattleOrder に変換
-        order = self._helper.action_index_to_order(self, battle, idx)
+        try:
+            order = self._helper.action_index_to_order(self, battle, idx)
+        except Exception as e:
+            print(
+                f"[DBG_STOP] MapleAgentPlayer action conversion error idx={idx} mapping={mapping} error={e}"
+            )
+            raise
         return order
 
     async def choose_team(self, battle) -> str:
         """チームプレビューに応答し、先頭3匹を選出する。"""
 
         # TODO: MapleAgent.choose_team に差し替え予定
-        return "/team 123"
+        team = "/team 123"
+        print(f"[DBG_STOP] MapleAgentPlayer.choose_team -> {team}")
+        return team
 
 
 __all__ = ["MapleAgentPlayer"]

--- a/src/env/env_player.py
+++ b/src/env/env_player.py
@@ -19,13 +19,17 @@ class EnvPlayer(Player):
         """Return the order chosen by the external agent via :class:`PokemonEnv`."""
 
         # PokemonEnv に最新の battle オブジェクトを送信
+        print("[DBG_STOP] EnvPlayer.choose_move put battle", battle.battle_tag, "turn", battle.turn)
         await self._env._battle_queue.put(battle)
 
         # PokemonEnv.step からアクションが投入されるまで待機
+        print("[DBG_STOP] EnvPlayer.choose_move wait action")
         action_data = await asyncio.wait_for(
             self._env._action_queue.get(), self._env.timeout
         )
         self._env._action_queue.task_done()
+
+        print("[DBG_STOP] EnvPlayer.choose_move got action", action_data)
 
         # 文字列はそのまま、整数は BattleOrder へ変換
         if isinstance(action_data, int):
@@ -41,6 +45,10 @@ class EnvPlayer(Player):
         from_teampreview_request: bool = False,
         maybe_default_order: bool = False,
     ):
+
+        print(
+            f"[DBG_STOP] EnvPlayer._handle_battle_request start tp={from_teampreview_request} turn={battle.turn} user={battle.player_username}"
+        )
 
         # 最初のターンでは ``battle.available_moves`` が更新されるまで待機する
         if battle.turn == 1 and not battle.available_moves:
@@ -83,3 +91,4 @@ class EnvPlayer(Player):
             message,
             battle.battle_tag,
         )
+        print("[DBG_STOP] EnvPlayer._handle_battle_request sent message", message)

--- a/src/env/pokemon_env.py
+++ b/src/env/pokemon_env.py
@@ -168,10 +168,12 @@ class PokemonEnv(gym.Env):
         )
 
         # チーム選択リクエストを待機
+        print("[DBG_STOP] PokemonEnv.reset waiting battle")
         battle = asyncio.run_coroutine_threadsafe(
             asyncio.wait_for(self._battle_queue.get(), self.timeout),
             POKE_LOOP,
         ).result()
+        print("[DBG_STOP] PokemonEnv.reset got battle", battle.battle_tag, "turn", getattr(battle, "turn", None))
         POKE_LOOP.call_soon_threadsafe(self._battle_queue.task_done)
         self._current_battle = battle
         observation = self.state_observer.observe(battle)
@@ -203,10 +205,13 @@ class PokemonEnv(gym.Env):
         if player_action is None:
             raise ValueError("player_0 action required")
 
+        print("[DBG_STOP] PokemonEnv.step action", player_action)
+
         if isinstance(player_action, str):
             asyncio.run_coroutine_threadsafe(
                 self._action_queue.put(player_action), POKE_LOOP
             ).result()
+            print("[DBG_STOP] PokemonEnv.step put team order", player_action)
         else:
             order = self.action_helper.action_index_to_order(
                 self._env_player, self._current_battle, int(player_action)
@@ -214,12 +219,15 @@ class PokemonEnv(gym.Env):
             asyncio.run_coroutine_threadsafe(
                 self._action_queue.put(order), POKE_LOOP
             ).result()
+            print("[DBG_STOP] PokemonEnv.step put order", order)
 
         # 次の状態を待機
+        print("[DBG_STOP] PokemonEnv.step waiting battle")
         battle = asyncio.run_coroutine_threadsafe(
             asyncio.wait_for(self._battle_queue.get(), self.timeout),
             POKE_LOOP,
         ).result()
+        print("[DBG_STOP] PokemonEnv.step got battle", battle.battle_tag, "turn", getattr(battle, "turn", None))
         POKE_LOOP.call_soon_threadsafe(self._battle_queue.task_done)
         self._current_battle = battle
 


### PR DESCRIPTION
## Summary
- instrument MapleAgent and MapleAgentPlayer with debug prints
- emit debug info in EnvPlayer request handling
- log steps in PokemonEnv during reset and step

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(no tests found)*
- `python test/run_battle.py` *(failed: ModuleNotFoundError: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_684b613c6c108330b60c96d628a4bd9e