### PR TITLE
実装: MapleAgentPlayer の teampreview メソッド追加

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,3 +1,7 @@
 from .MapleAgent import MapleAgent
+from .maple_agent_player import MapleAgentPlayer
 
-__all__ = ["MapleAgent"]
+__all__ = [
+    "MapleAgent",
+    "MapleAgentPlayer",
+]

--- a/src/agents/maple_agent_player.py
+++ b/src/agents/maple_agent_player.py
@@ -52,5 +52,12 @@ class MapleAgentPlayer(Player):
         print(f"[DBG_STOP] MapleAgentPlayer.choose_team -> {team}")
         return team
 
+    def teampreview(self, battle: Battle) -> str:
+        """チームプレビューでの選択を :class:`MapleAgent` に委譲する。"""
+
+        obs = self._observer.observe(battle)
+        team_cmd = self.maple_agent.choose_team(obs)
+        return team_cmd
+
 
 __all__ = ["MapleAgentPlayer"]


### PR DESCRIPTION
## Summary
- MapleAgentPlayer に `teampreview` メソッドを実装
- エージェントパッケージの `__all__` に MapleAgentPlayer を追加

## Testing
- `pytest -q`
- `python -m py_compile src/agents/maple_agent_player.py`
- `python -m py_compile src/agents/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_684b692c4e6883309bed35441123a055