### PR TITLE
Implement race_get for PokemonEnv

### DIFF
--- a/src/agents/MapleAgent.py
+++ b/src/agents/MapleAgent.py
@@ -56,7 +56,11 @@ class MapleAgent:
         if valid_indices:
             action_idx = int(self.env.rng.choice(valid_indices))
         else:
-            action_idx = int(self.env.action_space.sample())
+            # ``action_space`` は ``gym.spaces.Dict`` なので ``sample`` の
+            # 戻り値は辞書となる。ここでは単一エージェント分の離散
+            # 空間からサンプルする。
+            subspace = self.env.action_space[self.env.agent_ids[0]]
+            action_idx = int(subspace.sample())
 
         return action_idx
 

--- a/test/run_battle.py
+++ b/test/run_battle.py
@@ -62,8 +62,14 @@ def run_single_battle() -> dict:
         battle1 = env._current_battles[env.agent_ids[1]]
         mask0, _ = action_helper.get_available_actions_with_details(battle0)
         mask1, _ = action_helper.get_available_actions_with_details(battle1)
-        action_idx0 = agent0.select_action(current_obs0, mask0)
-        action_idx1 = agent1.select_action(current_obs1, mask1)
+
+        action_idx0 = 0
+        action_idx1 = 0
+        if env._need_action[env.agent_ids[0]]:
+            action_idx0 = agent0.select_action(current_obs0, mask0)
+        if env._need_action[env.agent_ids[1]]:
+            action_idx1 = agent1.select_action(current_obs1, mask1)
+
         observations, rewards, terms, truncs, _ = env.step(
             {"player_0": action_idx0, "player_1": action_idx1}
         )


### PR DESCRIPTION
## Summary
- add `_need_action` flags to track if each player must provide actions
- implement `_race_get` helper using `asyncio.wait`
- initialize `_need_action` in constructor and `reset`
- revise `step` to queue actions conditionally and fetch battles with `_race_get`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bd3560df08330b0b628ea51441665