### PR TITLE
Fix wait handling in battle script

### DIFF
--- a/src/agents/MapleAgent.py
+++ b/src/agents/MapleAgent.py
@@ -56,7 +56,11 @@ class MapleAgent:
         if valid_indices:
             action_idx = int(self.env.rng.choice(valid_indices))
         else:
-            action_idx = int(self.env.action_space.sample())
+            # ``action_space`` は ``gym.spaces.Dict`` なので ``sample`` の
+            # 戻り値は辞書となる。ここでは単一エージェント分の離散
+            # 空間からサンプルする。
+            subspace = self.env.action_space[self.env.agent_ids[0]]
+            action_idx = int(subspace.sample())
 
         return action_idx
 

--- a/test/run_battle.py
+++ b/test/run_battle.py
@@ -62,8 +62,14 @@ def run_single_battle() -> dict:
         battle1 = env._current_battles[env.agent_ids[1]]
         mask0, _ = action_helper.get_available_actions_with_details(battle0)
         mask1, _ = action_helper.get_available_actions_with_details(battle1)
-        action_idx0 = agent0.select_action(current_obs0, mask0)
-        action_idx1 = agent1.select_action(current_obs1, mask1)
+
+        action_idx0 = 0
+        action_idx1 = 0
+        if env._need_action[env.agent_ids[0]]:
+            action_idx0 = agent0.select_action(current_obs0, mask0)
+        if env._need_action[env.agent_ids[1]]:
+            action_idx1 = agent1.select_action(current_obs1, mask1)
+
         observations, rewards, terms, truncs, _ = env.step(
             {"player_0": action_idx0, "player_1": action_idx1}
         )


### PR DESCRIPTION
## Summary
- prevent random action sampling from dict space
- skip action selection when the agent is waiting

## Testing
- `pytest -q`
- `python -m py_compile test/run_battle.py src/agents/MapleAgent.py`

------
https://chatgpt.com/codex/tasks/task_e_684bd92c311c8330b5c01d47009e2d36