### PR TITLE
Implement dict output for env.step

### DIFF
--- a/src/env/pokemon_env.py
+++ b/src/env/pokemon_env.py
@@ -351,7 +351,13 @@ class PokemonEnv(gym.Env):
                 infos[self.agent_ids[0]],
             )
 
-        return observations, rewards, term_flags, trunc_flags, infos
+        return {
+            "observations": observations,
+            "rewards": rewards,
+            "terminated": term_flags,
+            "truncated": trunc_flags,
+            "infos": infos,
+        }
 
     # Step13: 終了判定ユーティリティ
     def _check_episode_end(self, battle: Any) -> tuple[bool, bool]:

--- a/test/run_battle.py
+++ b/test/run_battle.py
@@ -70,9 +70,16 @@ def run_single_battle() -> dict:
         if env._need_action[env.agent_ids[1]]:
             action_idx1 = agent1.select_action(current_obs1, mask1)
 
-        observations, rewards, terms, truncs, _ = env.step(
-            {"player_0": action_idx0, "player_1": action_idx1}
-        )
+        step_result = env.step({"player_0": action_idx0, "player_1": action_idx1})
+
+        if isinstance(step_result, dict):
+            observations = step_result["observations"]
+            rewards = step_result["rewards"]
+            terms = step_result["terminated"]
+            truncs = step_result["truncated"]
+        else:
+            observations, rewards, terms, truncs, _ = step_result
+
         current_obs0 = observations[env.agent_ids[0]]
         current_obs1 = observations[env.agent_ids[1]]
         done = terms[env.agent_ids[0]] or truncs[env.agent_ids[0]]


### PR DESCRIPTION
## Summary
- return multi-agent step results as a dictionary
- handle new return type in `run_battle.py`

## Testing
- `pytest -q` *(no tests found)*
- `python test/run_battle.py --n 1` *(fails: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_684c2b85dc348330bdca1881ba7b3a96