### PR TITLE
Implement replay buffer

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -2,10 +2,12 @@ from .MapleAgent import MapleAgent
 from .maple_agent_player import MapleAgentPlayer
 from .policy_network import PolicyNetwork
 from .RLAgent import RLAgent
+from .replay_buffer import ReplayBuffer
 
 __all__ = [
     "MapleAgent",
     "MapleAgentPlayer",
     "PolicyNetwork",
     "RLAgent",
+    "ReplayBuffer",
 ]

--- a/src/agents/replay_buffer.py
+++ b/src/agents/replay_buffer.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Tuple, List
+
+import numpy as np
+
+
+class ReplayBuffer:
+    """Simple experience replay buffer."""
+
+    def __init__(self, capacity: int) -> None:
+        self.capacity = int(capacity)
+        self.buffer: List[Tuple[np.ndarray, int, float, np.ndarray, bool]] = []
+        self.position = 0
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.buffer)
+
+    def add(
+        self,
+        state: np.ndarray,
+        action: int,
+        reward: float,
+        next_state: np.ndarray,
+        done: bool,
+    ) -> None:
+        """Store a transition in the buffer."""
+        data = (np.asarray(state), int(action), float(reward), np.asarray(next_state), bool(done))
+
+        if len(self.buffer) < self.capacity:
+            self.buffer.append(data)
+        else:
+            self.buffer[self.position] = data
+        self.position = (self.position + 1) % self.capacity
+
+    def sample(self, batch_size: int) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Randomly sample a batch of transitions."""
+        indices = np.random.choice(len(self.buffer), size=batch_size, replace=False)
+        states, actions, rewards, next_states, dones = zip(*(self.buffer[i] for i in indices))
+        return (
+            np.stack(states),
+            np.asarray(actions),
+            np.asarray(rewards, dtype=np.float32),
+            np.stack(next_states),
+            np.asarray(dones, dtype=np.float32),
+        )
+
+
+__all__ = ["ReplayBuffer"]

--- a/test/test_replay_buffer.py
+++ b/test/test_replay_buffer.py
@@ -1,3 +1,10 @@
+from pathlib import Path
+import sys
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
 import numpy as np
 
 from src.agents.replay_buffer import ReplayBuffer

--- a/test/test_replay_buffer.py
+++ b/test/test_replay_buffer.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+from src.agents.replay_buffer import ReplayBuffer
+
+
+def test_replay_buffer_capacity():
+    capacity = 5
+    buf = ReplayBuffer(capacity)
+    state = np.zeros(3)
+    next_state = np.ones(3)
+
+    for i in range(capacity + 2):
+        buf.add(state + i, i, float(i), next_state + i, i % 2 == 0)
+        assert len(buf) <= capacity
+    assert len(buf) == capacity


### PR DESCRIPTION
## Summary
- add basic `ReplayBuffer` for storing transitions with a fixed capacity
- export `ReplayBuffer` from agents package
- test that buffer length never exceeds its capacity

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684f7b59df708330bf3a587ec280517a