### PR TITLE
Fix team preview handling in RL training

### DIFF
--- a/src/env/wrappers.py
+++ b/src/env/wrappers.py
@@ -24,6 +24,10 @@ class SingleAgentCompatibilityWrapper(GymWrapper):
         # Enable single-agent mode in the underlying environment
         setattr(self.env, "single_agent_mode", True)
 
+    def __getattr__(self, name: str) -> Any:
+        """Delegate attribute access to the underlying environment."""
+        return getattr(self.env, name)
+
     @property
     def action_space(self) -> gym.Space:
         return self.env.action_space[self.env.agent_ids[0]]

--- a/src/env/wrappers.py
+++ b/src/env/wrappers.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from src.agents.MapleAgent import MapleAgent
+
 import gymnasium as gym
 
 try:  # Some tests stub out gymnasium
@@ -24,6 +26,11 @@ class SingleAgentCompatibilityWrapper(GymWrapper):
         # Enable single-agent mode in the underlying environment
         setattr(self.env, "single_agent_mode", True)
 
+        # 対戦相手としてランダム行動の ``MapleAgent`` を登録しておく
+        opponent = MapleAgent(self.env)
+        self.env.register_agent(opponent, "player_1")
+        self._opponent = opponent
+
     def __getattr__(self, name: str) -> Any:
         """Delegate attribute access to the underlying environment."""
         return getattr(self.env, name)
@@ -41,7 +48,24 @@ class SingleAgentCompatibilityWrapper(GymWrapper):
         return observation, info
 
     def step(self, action: Any):
-        return self.env.step({"player_0": action})
+        """Advance the environment one step with an automatic opponent."""
+
+        battle = self.env._current_battles.get(self.env.agent_ids[1])
+        if battle is not None:
+            if isinstance(action, str):
+                opp_action = self._opponent.choose_team(
+                    self.env.state_observer.observe(battle)
+                )
+            else:
+                mask, _ = self.env.action_helper.get_available_actions_with_details(
+                    battle
+                )
+                obs = self.env.state_observer.observe(battle)
+                opp_action = self._opponent.select_action(obs, mask)
+        else:
+            opp_action = 0
+
+        return self.env.step({"player_0": action, "player_1": opp_action})
 
 
 def make_single_agent_env(**kwargs: Any) -> gym.Env:

--- a/train_rl.py
+++ b/train_rl.py
@@ -60,11 +60,10 @@ def main(*, dry_run: bool = False, episodes: int = 1) -> None:
 
     env = init_env()
 
-    # For dry-run we only initialise the environment
-    observation, info = env.reset()
-    logger.info("Environment initialised")
-
     if dry_run:
+        # 初期化のみ確認して即終了
+        env.reset()
+        logger.info("Environment initialised")
         env.close()
         logger.info("Dry run complete")
         return
@@ -82,7 +81,7 @@ def main(*, dry_run: bool = False, episodes: int = 1) -> None:
         obs, info = env.reset()
         if info.get("request_teampreview"):
             team_cmd = agent.choose_team(obs)
-            obs, action_mask, reward, done, _ = env.step(team_cmd)
+            obs, action_mask, _, done, _ = env.step(team_cmd)
         else:
             battle = env.env._current_battles[env.env.agent_ids[0]]
             action_mask, _ = action_helper.get_available_actions_with_details(battle)


### PR DESCRIPTION
## Summary
- fix double reset when starting RL training
- support team preview step before main loop

## Testing
- `pytest`
- `python train_rl.py --dry-run` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6850e3a0fed48330b84fc216ca0f89ea