### PR TITLE
Fix circular import in wrappers

### DIFF
--- a/src/env/wrappers.py
+++ b/src/env/wrappers.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from src.agents.MapleAgent import MapleAgent
 
 import gymnasium as gym
 
@@ -27,6 +26,7 @@ class SingleAgentCompatibilityWrapper(GymWrapper):
         setattr(self.env, "single_agent_mode", True)
 
         # 対戦相手としてランダム行動の ``MapleAgent`` を登録しておく
+        from src.agents.MapleAgent import MapleAgent
         opponent = MapleAgent(self.env)
         self.env.register_agent(opponent, "player_1")
         self._opponent = opponent


### PR DESCRIPTION
## Summary
- avoid importing MapleAgent at module load
- import MapleAgent inside `SingleAgentCompatibilityWrapper` constructor to break the cycle

## Testing
- `pytest -q`
- `python test/run_battle.py` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6850ee6397708330b267861b2156beb5