### PR TITLE
Add logging of RL action mask

### DIFF
--- a/src/agents/RLAgent.py
+++ b/src/agents/RLAgent.py
@@ -35,6 +35,8 @@ class RLAgent(MapleAgent):
 
     def act(self, observation: np.ndarray, action_mask: np.ndarray) -> int:
         """Sample an action index according to the policy."""
+        # Print the received mask to make debugging of invalid actions easier
+        print(f"available mask = {action_mask}")
         probs = self.select_action(observation, action_mask)
         rng = getattr(self.env, "rng", np.random.default_rng())
         return int(rng.choice(len(probs), p=probs))


### PR DESCRIPTION
## Summary
- log the current action mask in `RLAgent.act` so it's easy to inspect which moves are available during training

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685117063ab48330a14c1f27bf6aff12