### PR TITLE
Fix switch command in BattleOrder

### DIFF
--- a/copy_of_poke-env/poke_env/player/battle_order.py
+++ b/copy_of_poke-env/poke_env/player/battle_order.py
@@ -42,7 +42,11 @@ class BattleOrder:
                 message += f" {self.move_target}"
             return message
         elif isinstance(self.order, Pokemon):
-            return f"/choose switch {self.order.species}"
+            # Use the Pokémon's display name rather than the lowercase species
+            # identifier to avoid mismatch issues when team preview trims the
+            # roster.  Showdown accepts nicknames or species names, so we use
+            # ``name`` which preserves capitalization.
+            return f"/choose switch {self.order.name}"
         else:
             return ""
 


### PR DESCRIPTION
## Summary
- ensure Pokemon switches use display names rather than lowercase species IDs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68539763d7e483309a08d48d3403464c