### PR TITLE
Implement evaluation stats for M5 step9

### DIFF
--- a/evaluate_rl.py
+++ b/evaluate_rl.py
@@ -78,6 +78,10 @@ def main(model_path: str, n: int = 1) -> None:
     env.close()
     logger.info("Evaluation finished after %d battles", n)
 
+    win_rate = wins / n if n else 0.0
+    avg_reward = total_reward / n if n else 0.0
+    logger.info("win_rate: %.2f avg_reward: %.2f", win_rate, avg_reward)
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format="%(message)s")


### PR DESCRIPTION
## Summary
- add win rate and average reward logging in `evaluate_rl.py`

## Testing
- `pytest` *(no tests were collected)*

------
https://chatgpt.com/codex/tasks/task_e_68541a7b23388330b73184cb66ce9eee