### PR TITLE
Implement training config loader

### DIFF
--- a/config/train_config.yml
+++ b/config/train_config.yml
@@ -1,0 +1,4 @@
+episodes: 10
+lr: 0.001
+batch_size: 32
+buffer_capacity: 1000


### PR DESCRIPTION
## Summary
- support YAML training configuration in `train_rl.py`
- read new `config/train_config.yml` for hyperparameters

## Testing
- `black train_rl.py config/train_config.yml`
- `ruff check train_rl.py config/train_config.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68541d2004dc83308c6e1ca9067b2ac5