### PR TITLE
Improve debugging for invalid actions

### DIFF
--- a/src/action/action_helper.py
+++ b/src/action/action_helper.py
@@ -1,12 +1,15 @@
 # src/action/action_helper.py
 from typing import List, Tuple, Dict, Union, TypedDict
 import numpy as np
+import logging
 
 from poke_env.environment.battle import Battle
 from poke_env.environment.move import Move
 from poke_env.environment.pokemon import Pokemon
 from poke_env.player.player import Player
 from poke_env.player.battle_order import BattleOrder
+
+logger = logging.getLogger(__name__)
 
 # -----------------------------------------------------------------------------
 # Mask generation utilities
@@ -155,6 +158,11 @@ def action_index_to_order_from_mapping(
     switches_list: List[Pokemon] = battle.available_switches
 
     if action_index not in mapping:
+        logger.error(
+            "Invalid or unavailable action index: %s. Available: %s",
+            action_index,
+            mapping,
+        )
         raise ValueError(
             f"Invalid or unavailable action index: {action_index}. Available: {mapping}"
         )

--- a/src/agents/RLAgent.py
+++ b/src/agents/RLAgent.py
@@ -39,7 +39,9 @@ class RLAgent(MapleAgent):
         print(f"available mask = {action_mask}")
         probs = self.select_action(observation, action_mask)
         rng = getattr(self.env, "rng", np.random.default_rng())
-        return int(rng.choice(len(probs), p=probs))
+        action = int(rng.choice(len(probs), p=probs))
+        print(f"chosen action = {action}")
+        return action
 
 
 __all__ = ["RLAgent"]

--- a/src/env/pokemon_env.py
+++ b/src/env/pokemon_env.py
@@ -320,6 +320,8 @@ class PokemonEnv(gym.Env):
                     }
             else:
                 mapping = self._action_mappings.get(agent_id) or {}
+                self._logger.debug("received action %s for %s", act, agent_id)
+                self._logger.debug("current mapping for %s: %s", agent_id, mapping)
                 if mapping:
                     order = self.action_helper.action_index_to_order_from_mapping(
                         self._env_players[agent_id],
@@ -361,6 +363,8 @@ class PokemonEnv(gym.Env):
                 self._need_action[pid] = True
             battles[pid] = battle
             mask, mapping = self.action_helper.get_available_actions(battle)
+            self._logger.debug("available mask for %s: %s", pid, mask)
+            self._logger.debug("available mapping for %s: %s", pid, mapping)
             selected = self._selected_species.get(pid)
             if selected:
                 for idx, (atype, sub_idx) in mapping.items():


### PR DESCRIPTION
## Summary
- print the chosen action in `RLAgent`
- log mappings and masks in `PokemonEnv.step`
- log invalid action indices in `action_helper`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a930eb088330895b237497e7b95d