### PR TITLE
Fix initial action mask after team preview

### DIFF
--- a/src/env/pokemon_env.py
+++ b/src/env/pokemon_env.py
@@ -292,6 +292,8 @@ class PokemonEnv(gym.Env):
             asyncio.wait_for(_race(), self.timeout),
             POKE_LOOP,
         ).result()
+        if result is None and not queue.empty():
+            result = asyncio.run_coroutine_threadsafe(queue.get(), POKE_LOOP).result()
         if result is not None:
             POKE_LOOP.call_soon_threadsafe(queue.task_done)
         return result


### PR DESCRIPTION
## Summary
- ensure _race_get consumes queued battle updates when events are triggered

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854bfaec1c48330a3e46167e3b7fa37