### PR TITLE
Fix race condition fetching battle update

### DIFF
--- a/src/env/pokemon_env.py
+++ b/src/env/pokemon_env.py
@@ -286,6 +286,9 @@ class PokemonEnv(gym.Env):
                 p.cancel()
             if get_task in done:
                 return get_task.result()
+            # イベントが先に完了した場合でも、キューにデータが残っていれば取得する
+            if not queue.empty():
+                return await queue.get()
             return None
 
         result = asyncio.run_coroutine_threadsafe(


### PR DESCRIPTION
## Summary
- ensure `_race_get` fetches pending battle message even when waiting events fire first

## Testing
- `pytest -q` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6854cb75a33883309ec853e4fad5c6cf