### PR TITLE
Fix action mask usage in scripts

### DIFF
--- a/evaluate_rl.py
+++ b/evaluate_rl.py
@@ -47,8 +47,9 @@ def run_episode(agent: RLAgent) -> tuple[bool, float]:
         team_cmd = agent.choose_team(obs)
         obs, action_mask, _, done, _ = env.step(team_cmd)
     else:
-        battle = env.env.get_current_battle(env.env.agent_ids[0])
-        action_mask, _ = action_helper.get_available_actions_with_details(battle)
+        action_mask, _ = env.env.get_action_mask(
+            env.env.agent_ids[0], with_details=True
+        )
         done = False
     total_reward = 0.0
     while not done:

--- a/test/run_battle.py
+++ b/test/run_battle.py
@@ -86,10 +86,8 @@ def run_single_battle(model_path: str | None = None) -> dict:
     done = False
     last_reward = 0.0
     while not done:
-        battle0 = env.get_current_battle(env.agent_ids[0])
-        battle1 = env.get_current_battle(env.agent_ids[1])
-        mask0, _ = action_helper.get_available_actions_with_details(battle0)
-        mask1, _ = action_helper.get_available_actions_with_details(battle1)
+        mask0, _ = env.get_action_mask(env.agent_ids[0], with_details=True)
+        mask1, _ = env.get_action_mask(env.agent_ids[1], with_details=True)
 
         action_idx0 = 0
         action_idx1 = 0

--- a/train_rl.py
+++ b/train_rl.py
@@ -130,8 +130,9 @@ def main(
             team_cmd = agent.choose_team(obs)
             obs, action_mask, _, done, _ = env.step(team_cmd)
         else:
-            battle = env.env.get_current_battle(env.env.agent_ids[0])
-            action_mask, _ = action_helper.get_available_actions_with_details(battle)
+            action_mask, _ = env.env.get_action_mask(
+                env.env.agent_ids[0], with_details=True
+            )
             done = False
 
         total_reward = 0.0


### PR DESCRIPTION
## Summary
- update run_battle, train_rl, and evaluate_rl to use `env.get_action_mask(..., with_details=True)`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685500ebc6f883309727a74061ebe79b