### PR TITLE
Fix first-turn action mask generation

### DIFF
--- a/src/env/pokemon_env.py
+++ b/src/env/pokemon_env.py
@@ -333,9 +333,10 @@ class PokemonEnv(gym.Env):
             # _waiting イベントがトリガーされた直後にキューへバトルデータが
             # 追加される場合がある。直後にチェックすると空のままになってしまい
             # マスク生成に失敗するため、僅かに待機してから再確認する。
-            await asyncio.sleep(0)  # タスク切り替えを促す
-            if not queue.empty():
-                return await queue.get()
+            for _ in range(5):
+                await asyncio.sleep(0.05)  # タスク切り替えを促す
+                if not queue.empty():
+                    return await queue.get()
             return None
 
         result = asyncio.run_coroutine_threadsafe(


### PR DESCRIPTION
## Summary
- wait a bit longer when battle events fire before assuming no data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685515744ba88330980235064d3bd812