### PR TITLE
Implement battle seed option

### DIFF
--- a/copy_of_poke-env/poke_env/ps_client/ps_client.py
+++ b/copy_of_poke-env/poke_env/ps_client/ps_client.py
@@ -96,10 +96,19 @@ class PSClient:
         await self.set_team(packed_team)
         await self.send_message("/accept %s" % username)
 
-    async def challenge(self, username: str, format_: str, packed_team: Optional[str]):
+    async def challenge(
+        self,
+        username: str,
+        format_: str,
+        packed_team: Optional[str],
+        *,
+        seed: int | None = None,
+    ):
         assert self.logged_in.is_set(), f"Expected {self.username} to be logged in."
         await self.set_team(packed_team)
         await self.send_message(f"/challenge {username}, {format_}")
+        if seed is not None:
+            await self.send_message(f'>start {{"seed": {seed}}}')
 
     def _create_logger(self, log_level: Optional[int]) -> Logger:
         """Creates a logger for the client.

--- a/docs/M4_setup.md
+++ b/docs/M4_setup.md
@@ -46,3 +46,13 @@ pytest -q
 
 - [M4 backlog](AI-design/M4/M4_backlog.md)
 - [PokemonEnv 技術仕様書](AI-design/PokemonEnv_Specification.md)
+
+## 8. バトルシードを固定する
+
+学習 (`train_rl.py`) や評価 (`evaluate_rl.py`) では `--battle-seed` を指定することで
+Showdown 側の乱数シードを固定できます。実験を再現したい場合に利用してください。
+
+```bash
+python train_rl.py --episodes 10 --battle-seed 123
+python evaluate_rl.py --model model.pt --battle-seed 123
+```

--- a/src/env/env_player.py
+++ b/src/env/env_player.py
@@ -20,6 +20,17 @@ class EnvPlayer(Player):
         self.player_id = player_id
         self._logger = logging.getLogger(__name__)
 
+    async def battle_against(
+        self,
+        *opponents: Player,
+        n_battles: int = 1,
+        battle_seed: int | None = None,
+    ):
+        """Wrapper to propagate ``battle_seed`` to :class:`Player`."""
+        return await super().battle_against(
+            *opponents, n_battles=n_battles, battle_seed=battle_seed
+        )
+
     async def choose_move(self, battle):
         """Return the order chosen by the external agent via :class:`PokemonEnv`."""
 


### PR DESCRIPTION
## Summary
- add `battle_seed` support across env, players and PSClient
- expose `--battle-seed` in training/evaluation scripts
- document deterministic battle execution in setup guide

## Testing
- `black . --check`
- `ruff check .` *(fails: E402 in test files)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685674cdc57c83308878b45602c38bbe