### PR TITLE
Fix log parsing for UTF-16 output

### DIFF
--- a/docs/AI-design/M5/M5_backlog.md
+++ b/docs/AI-design/M5/M5_backlog.md
@@ -28,7 +28,7 @@
 |18| ドキュメント更新 | M5 開始方法と学習手順を `docs/M5_setup.md` に記述 | ドキュメントを参照し手順通り実行できる | Markdown |
 |19| 実験ログ管理 | `logs/` ディレクトリを作り実験毎にファイル保存 | ログファイルに日時とパラメータが記録される | logging |
 |20| 乱数シード制御 | 学習・評価とも `--seed` オプションで再現性確保 | 同じシード指定で結果がほぼ一致。Showdown サーバの PRNG は制御できないため完全な再現はできず、本ステップはスキップ | numpy RNG |
-|21| 学習結果の図示 | 勝率推移などを matplotlib でプロット | `python plot_results.py logs/run1.json` が図を保存 | matplotlib |
+|21| 学習結果の図示 | 勝率推移などを matplotlib でプロット | `python plot_results.py logs/run1.json` が図を保存（ログは UTF-16 で記録され、最終行に JSON データが含まれる） | matplotlib |
 |22| バトルリプレイ保存 | Showdown のリプレイログを保管 | 評価時に `replays/` フォルダへ HTML が出力される | poke-env `save_replay` |
 |23| 複数モデル比較機能 | 複数の重みファイルをロードし対戦させる | `evaluate_rl.py --models a.pt b.pt` が両者の勝率を表示 | Python CLI |
 |24| 学習時間計測 | 1 エピソード当たりの処理時間を計測 | ログに `time/episode:` が表示される | time, logging |

--- a/plot_results.py
+++ b/plot_results.py
@@ -7,9 +7,25 @@ import matplotlib.pyplot as plt
 
 
 def load_results(path: str) -> List[dict]:
-    """Load battle results list from a JSON file."""
-    with open(path, "r", encoding="utf-8") as f:
-        data = json.load(f)
+    """Load battle results list from a log file containing JSON output."""
+
+    encodings = ["utf-8", "utf-8-sig", "utf-16"]
+    text: str | None = None
+    for enc in encodings:
+        try:
+            with open(path, "r", encoding=enc) as f:
+                text = f.read()
+            break
+        except UnicodeDecodeError:  # pragma: no cover - fallback
+            continue
+    if text is None:
+        raise UnicodeDecodeError("utf-8", b"", 0, 1, "Unable to decode log file")
+
+    start_idx = text.rfind("{")
+    if start_idx == -1:
+        raise ValueError("No JSON object found in log")
+
+    data = json.loads(text[start_idx:])
     results = data.get("results")
     if not isinstance(results, list):
         raise ValueError("Invalid log format: 'results' list missing")


### PR DESCRIPTION
## Summary
- handle UTF-16 encoded logs in `plot_results.py`
- describe log format in backlog doc

## Testing
- `pytest -q`
- `python plot_results.py logs/run1.json` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_6856a25d810c8330b8ac969dd4a07f40