### PR TITLE
Implement replay saving for evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 __pycache__/
 src/env/__pycache__/
 .vscode
+replays/

--- a/src/env/pokemon_env.py
+++ b/src/env/pokemon_env.py
@@ -30,6 +30,7 @@ class PokemonEnv(gym.Env):
         opponent_player: Any | None = None,
         *,
         seed: int | None = None,
+        save_replays: bool | str = False,
         **kwargs: Any,
     ) -> None:
         super().__init__()
@@ -54,6 +55,7 @@ class PokemonEnv(gym.Env):
         self.state_observer = state_observer
         self.action_helper = action_helper
         self.rng = np.random.default_rng(seed)
+        self.save_replays = save_replays
         self._logger = logging.getLogger(__name__)
 
         # マルチエージェント用のエージェントID
@@ -230,6 +232,7 @@ class PokemonEnv(gym.Env):
                     server_configuration=LocalhostServerConfiguration,
                     team=team,
                     log_level=logging.DEBUG,
+                    save_replays=self.save_replays,
                 )
             }
             if self.opponent_player is None:
@@ -240,6 +243,7 @@ class PokemonEnv(gym.Env):
                     server_configuration=LocalhostServerConfiguration,
                     team=team,
                     log_level=logging.DEBUG,
+                    save_replays=self.save_replays,
                 )
             else:
                 self._env_players["player_1"] = self.opponent_player


### PR DESCRIPTION
## Summary
- add `save_replays` option in `PokemonEnv`
- enable specifying replay directory from `evaluate_rl.py`
- ignore generated `replays/` directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856a54959408330879d92dc4fcbc7e1