### PR TITLE
Implement M6 step1: unified env interface

### DIFF
--- a/evaluate_rl.py
+++ b/evaluate_rl.py
@@ -88,14 +88,17 @@ def run_episode_multi(agent0: RLAgent, agent1: RLAgent) -> tuple[bool, bool, flo
     """Run one battle between two agents and return win flags and rewards."""
 
     env = agent0.env
-    observations, info = env.reset()
+    data = env.reset()
+    observations = data["obs"]
+    info = data["info"]
     obs0 = observations[env.agent_ids[0]]
     obs1 = observations[env.agent_ids[1]]
 
     if info.get("request_teampreview"):
         order0 = agent0.choose_team(obs0)
         order1 = agent1.choose_team(obs1)
-        observations, *_ = env.step({"player_0": order0, "player_1": order1})
+        step_result = env.step({"player_0": order0, "player_1": order1})
+        observations = step_result["obs"]
         obs0 = observations[env.agent_ids[0]]
         obs1 = observations[env.agent_ids[1]]
 
@@ -107,7 +110,11 @@ def run_episode_multi(agent0: RLAgent, agent1: RLAgent) -> tuple[bool, bool, flo
         mask1, _ = env.get_action_mask(env.agent_ids[1], with_details=True)
         action0 = agent0.act(obs0, mask0) if env._need_action[env.agent_ids[0]] else 0
         action1 = agent1.act(obs1, mask1) if env._need_action[env.agent_ids[1]] else 0
-        observations, rewards, terms, truncs, _ = env.step({"player_0": action0, "player_1": action1})
+        step_result = env.step({"player_0": action0, "player_1": action1})
+        observations = step_result["obs"]
+        rewards = step_result["rewards"]
+        terms = step_result["terminated"]
+        truncs = step_result["truncated"]
         obs0 = observations[env.agent_ids[0]]
         obs1 = observations[env.agent_ids[1]]
         reward0 += float(rewards[env.agent_ids[0]])

--- a/src/env/pokemon_env.py
+++ b/src/env/pokemon_env.py
@@ -295,10 +295,7 @@ class PokemonEnv(gym.Env):
             "request_teampreview": True,
         }
 
-        if hasattr(self, "single_agent_mode"):
-            return observation[self.agent_ids[0]], info
-
-        return observation, info
+        return {"obs": observation, "info": info}
 
     async def _run_battle(self) -> None:
         """Start the battle coroutines concurrently."""
@@ -435,24 +432,15 @@ class PokemonEnv(gym.Env):
         if any(truncated.values()):
             rewards = {agent_id: 0.0 for agent_id in self.agent_ids}
 
-        observations = observation
-        term_flags = terminated
-        trunc_flags = truncated
         infos = {agent_id: {} for agent_id in self.agent_ids}
 
-        if hasattr(self, "single_agent_mode"):
-            action_mask, mapping = self.get_action_mask(self.agent_ids[0])
-            self._action_mappings[self.agent_ids[0]] = mapping
-            done = terminated[self.agent_ids[0]] or truncated[self.agent_ids[0]]
-            return (
-                observation[self.agent_ids[0]],
-                action_mask,
-                rewards[self.agent_ids[0]],
-                done,
-                infos[self.agent_ids[0]],
-            )
-
-        return observations, rewards, term_flags, trunc_flags, infos
+        return {
+            "obs": observation,
+            "rewards": rewards,
+            "terminated": terminated,
+            "truncated": truncated,
+            "info": infos,
+        }
 
     # Step13: 終了判定ユーティリティ
     def _check_episode_end(self, battle: Any) -> tuple[bool, bool]:

--- a/test/run_battle.py
+++ b/test/run_battle.py
@@ -72,14 +72,17 @@ def run_single_battle(model_path: str | None = None) -> dict:
     agent1 = MapleAgent(env)
     env.register_agent(agent1, "player_1")
 
-    observations, info = env.reset()
+    data = env.reset()
+    observations = data["obs"]
+    info = data["info"]
     current_obs0 = observations[env.agent_ids[0]]
     current_obs1 = observations[env.agent_ids[1]]
 
     if info.get("request_teampreview"):
         order0 = agent0.choose_team(current_obs0)
         order1 = agent1.choose_team(current_obs1)
-        observations, *_ = env.step({"player_0": order0, "player_1": order1})
+        step_result = env.step({"player_0": order0, "player_1": order1})
+        observations = step_result["obs"]
         current_obs0 = observations[env.agent_ids[0]]
         current_obs1 = observations[env.agent_ids[1]]
 
@@ -99,9 +102,11 @@ def run_single_battle(model_path: str | None = None) -> dict:
         if env._need_action[env.agent_ids[1]]:
             action_idx1 = agent1.select_action(current_obs1, mask1)
 
-        observations, rewards, terms, truncs, _ = env.step(
-            {"player_0": action_idx0, "player_1": action_idx1}
-        )
+        step_result = env.step({"player_0": action_idx0, "player_1": action_idx1})
+        observations = step_result["obs"]
+        rewards = step_result["rewards"]
+        terms = step_result["terminated"]
+        truncs = step_result["truncated"]
         last_reward = float(rewards[env.agent_ids[0]])
         current_obs0 = observations[env.agent_ids[0]]
         current_obs1 = observations[env.agent_ids[1]]


### PR DESCRIPTION
## Summary
- update PokemonEnv.reset and step to return dictionary-based results
- adapt SingleAgentCompatibilityWrapper to new API
- adjust run_battle and evaluation scripts to parse new format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68575a84b3ec83308e33078f3f4972d4