### PR TITLE
Implement algorithm abstraction per M6 step2

### DIFF
--- a/src/agents/RLAgent.py
+++ b/src/agents/RLAgent.py
@@ -6,17 +6,23 @@ import torch.nn as nn
 
 from .MapleAgent import MapleAgent
 from src.env.pokemon_env import PokemonEnv
+from src.algorithms import BaseAlgorithm, ReinforceAlgorithm
 
 
 class RLAgent(MapleAgent):
     """Reinforcement learning agent holding a model and optimizer."""
 
     def __init__(
-        self, env: PokemonEnv, model: nn.Module, optimizer: torch.optim.Optimizer
+        self,
+        env: PokemonEnv,
+        model: nn.Module,
+        optimizer: torch.optim.Optimizer,
+        algorithm: BaseAlgorithm | None = None,
     ) -> None:
         super().__init__(env)
         self.model = model
         self.optimizer = optimizer
+        self.algorithm = algorithm or ReinforceAlgorithm()
 
     def select_action(
         self, observation: np.ndarray, action_mask: np.ndarray
@@ -42,6 +48,10 @@ class RLAgent(MapleAgent):
         action = int(rng.choice(len(probs), p=probs))
         print(f"{self.__class__.__name__}: chosen action = {action}")
         return action
+
+    def update(self, batch: dict[str, torch.Tensor]) -> float:
+        """Delegate a training update to the underlying algorithm."""
+        return self.algorithm.update(self.model, self.optimizer, batch)
 
 
 __all__ = ["RLAgent"]

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -3,6 +3,7 @@ from .maple_agent_player import MapleAgentPlayer
 from .policy_network import PolicyNetwork
 from .RLAgent import RLAgent
 from .replay_buffer import ReplayBuffer
+from src.algorithms import BaseAlgorithm, ReinforceAlgorithm, DummyAlgorithm
 
 __all__ = [
     "MapleAgent",
@@ -10,4 +11,7 @@ __all__ = [
     "PolicyNetwork",
     "RLAgent",
     "ReplayBuffer",
+    "BaseAlgorithm",
+    "ReinforceAlgorithm",
+    "DummyAlgorithm",
 ]

--- a/src/algorithms/__init__.py
+++ b/src/algorithms/__init__.py
@@ -1,0 +1,9 @@
+from .base import BaseAlgorithm
+from .reinforce import ReinforceAlgorithm
+from .dummy import DummyAlgorithm
+
+__all__ = [
+    "BaseAlgorithm",
+    "ReinforceAlgorithm",
+    "DummyAlgorithm",
+]

--- a/src/algorithms/base.py
+++ b/src/algorithms/base.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Dict
+
+import torch
+import torch.nn as nn
+
+
+class BaseAlgorithm(ABC):
+    """Interface for reinforcement learning algorithms."""
+
+    @abstractmethod
+    def update(
+        self,
+        model: nn.Module,
+        optimizer: torch.optim.Optimizer,
+        batch: Dict[str, torch.Tensor],
+    ) -> float:
+        """Update ``model`` using ``batch`` and return the training loss."""
+        raise NotImplementedError

--- a/src/algorithms/dummy.py
+++ b/src/algorithms/dummy.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import torch
+import torch.nn as nn
+
+from .base import BaseAlgorithm
+
+
+class DummyAlgorithm(BaseAlgorithm):
+    """Algorithm placeholder that performs no updates."""
+
+    def update(
+        self,
+        model: nn.Module,
+        optimizer: torch.optim.Optimizer,
+        batch: Dict[str, torch.Tensor],
+    ) -> float:
+        del model, optimizer, batch
+        return 0.0

--- a/src/algorithms/reinforce.py
+++ b/src/algorithms/reinforce.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import torch
+import torch.nn as nn
+
+from .base import BaseAlgorithm
+
+
+class ReinforceAlgorithm(BaseAlgorithm):
+    """Monte Carlo policy gradient (REINFORCE) implementation."""
+
+    def update(
+        self,
+        model: nn.Module,
+        optimizer: torch.optim.Optimizer,
+        batch: Dict[str, torch.Tensor],
+    ) -> float:
+        obs = torch.as_tensor(batch["observations"], dtype=torch.float32)
+        actions = torch.as_tensor(batch["actions"], dtype=torch.int64)
+        rewards = torch.as_tensor(batch["rewards"], dtype=torch.float32)
+
+        logits = model(obs)
+        log_probs = torch.log_softmax(logits, dim=-1)
+        selected = log_probs[torch.arange(len(actions)), actions]
+        loss = -(selected * rewards).mean()
+
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+        return float(loss.detach())


### PR DESCRIPTION
## Summary
- refactor RLAgent to delegate updates to pluggable algorithms
- create a simple algorithm framework with REINFORCE and dummy implementations
- update training loop to use the new abstraction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857618544ec83309db7ef979bbc360c