### PR TITLE
Add bonus reward for high remaining HP

### DIFF
--- a/docs/AI-design/M4/M4_backlog.md
+++ b/docs/AI-design/M4/M4_backlog.md
@@ -18,7 +18,7 @@
 | 9 | step スケルトン実装 | `step(action)` が 5 要素タプルを返す形だけ用意 | ダミー値でも呼び出し可能 | `env.step(0)` を実行し例外無し | Gymnasium 仕様 |
 |10| 非同期アクションキュー | `asyncio.Queue` を導入し `choose_move` がキューから行動を取得 | キューへインデックスを投入すると `choose_move` が対応する `BattleOrder` を返す | 単体テストでキュー処理を検証 | asyncio.Queue, action_helper |
 |11| エピソード完走確認 | 対戦が最後まで実行できるか検証 | `python random_rollout.py --episodes 1` が完走する | ログに最終ターンが表示される | poke-env, asyncio |
-|12| 報酬計算関数 | `_calc_reward(battle)` で勝敗に応じ ±1 を返す | 実際の対戦で +1 / -1 / 0 を確認 | 実践で確認 | poke-env Battle API |
+|12| 報酬計算関数 | `_calc_reward(battle)` で勝敗に応じ ±1 （残HP合計が1.5以上なら+0.05ボーナス）を返す | 実際の対戦で +1 / -1 / 0 を確認 | 実践で確認 | poke-env Battle API |
 |13| 終了判定処理 | `terminated` と `truncated` のロジック実装 | `_check_episode_end()` で `battle.finished` または `turn > MAX_TURNS` を判定 | 実戦でフラグ確認 | Battle 属性参照 |
 |14| ターン同期機構 | `_race_get` を用いて最新 `request` を取得 | `rqid` 乱序でもターンが進む | 強制交代シナリオで確認 | asyncio, rqid 管理 |
 |15| step 出力整備 | observations, rewards, terminated, truncated, infosを player識別子(`player_0`,`player_1`)をキーとしたdictで返す | ランダムエージェントで 1 戦完走 | `run_battle.py` 実行 | 全機能統合 |

--- a/docs/AI-design/PokemonEnv_Specification.md
+++ b/docs/AI-design/PokemonEnv_Specification.md
@@ -156,6 +156,7 @@ sequenceDiagram
 | 途中ターン | False | 0 |
 
 報酬は `{"player_0": float, "player_1": float}` 形式で返る。
+勝利した際、チームの残りHP割合合計が1.5以上なら報酬に0.05を追加する。
 
 ---
 

--- a/src/env/pokemon_env.py
+++ b/src/env/pokemon_env.py
@@ -154,7 +154,10 @@ class PokemonEnv(gym.Env):
         if selected:
             if with_details:
                 for idx, detail in mapping.items():
-                    if detail.get("type") == "switch" and detail.get("id") not in selected:
+                    if (
+                        detail.get("type") == "switch"
+                        and detail.get("id") not in selected
+                    ):
                         mask[idx] = 0
             else:
                 for idx, (atype, sub_idx) in mapping.items():
@@ -472,7 +475,15 @@ class PokemonEnv(gym.Env):
 
         # battle.won が True なら勝利、False なら敗北とみなす
         if getattr(battle, "won", False):
-            return 1.0
+            reward = 1.0
+            # 自分の残りHP割合の合計が1.5以上ならボーナスを付与
+            try:
+                remain_hp = sum(p.current_hp_fraction for p in battle.team.values())
+                if remain_hp >= 1.5:
+                    reward += 0.05
+            except Exception:
+                pass
+            return reward
         return -1.0
 
     def render(self) -> None:


### PR DESCRIPTION
## Summary
- give a 0.05 bonus reward if winning with team HP fraction >=1.5
- document the new HP bonus rule
- reflect the change in the M4 backlog spec

## Testing
- `ruff check .` *(fails: E402 in test_get_action_mask.py)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857af29a5e48330843f59fbbc0e766d