### PR TITLE
Implement GAE advantage computation

### DIFF
--- a/src/algorithms/__init__.py
+++ b/src/algorithms/__init__.py
@@ -1,9 +1,11 @@
 from .base import BaseAlgorithm
 from .reinforce import ReinforceAlgorithm
 from .dummy import DummyAlgorithm
+from .gae import compute_gae
 
 __all__ = [
     "BaseAlgorithm",
     "ReinforceAlgorithm",
     "DummyAlgorithm",
+    "compute_gae",
 ]

--- a/src/algorithms/gae.py
+++ b/src/algorithms/gae.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+
+def compute_gae(
+    rewards: Sequence[float],
+    values: Sequence[float],
+    gamma: float = 0.99,
+    lam: float = 0.95,
+    last_value: float = 0.0,
+) -> np.ndarray:
+    """Compute Generalized Advantage Estimation (GAE)."""
+    rewards_arr = np.asarray(rewards, dtype=np.float32)
+    values_arr = np.asarray(values, dtype=np.float32)
+    if len(rewards_arr) != len(values_arr):
+        raise ValueError("rewards and values must have the same length")
+
+    advantages = np.zeros_like(rewards_arr, dtype=np.float32)
+    gae = 0.0
+    for t in range(len(rewards_arr) - 1, -1, -1):
+        next_value = values_arr[t + 1] if t + 1 < len(values_arr) else last_value
+        delta = rewards_arr[t] + gamma * next_value - values_arr[t]
+        gae = delta + gamma * lam * gae
+        advantages[t] = gae
+    return advantages
+
+__all__ = ["compute_gae"]

--- a/test/test_compute_gae.py
+++ b/test/test_compute_gae.py
@@ -1,0 +1,56 @@
+from types import ModuleType, SimpleNamespace
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+np_stub = ModuleType("numpy")
+np_stub.float32 = "float32"
+np_stub.int8 = "int8"
+np_stub.ndarray = list
+np_stub.random = SimpleNamespace(default_rng=lambda seed=None: None)
+np_stub.zeros = lambda shape, dtype=None: [0.0] * shape
+np_stub.array = lambda data, dtype=None: list(data)
+
+def asarray(data, dtype=None):
+    return list(data)
+
+
+def zeros_like(a, dtype=None):
+    return [0.0 for _ in a]
+
+
+def allclose(a, b, atol=1e-8, rtol=1e-5):
+    if len(a) != len(b):
+        return False
+    for x, y in zip(a, b):
+        if abs(x - y) > atol + rtol * abs(y):
+            return False
+    return True
+
+
+np_stub.asarray = asarray
+np_stub.zeros_like = zeros_like
+np_stub.allclose = allclose
+sys.modules.setdefault("numpy", np_stub)
+sys.modules.setdefault("numpy.random", np_stub.random)
+np = np_stub
+
+# Create a minimal torch stub so that importing algorithms does not fail
+torch_stub = ModuleType("torch")
+torch_stub.nn = ModuleType("torch.nn")
+torch_stub.optim = ModuleType("torch.optim")
+sys.modules.setdefault("torch", torch_stub)
+sys.modules.setdefault("torch.nn", torch_stub.nn)
+sys.modules.setdefault("torch.optim", torch_stub.optim)
+
+from src.algorithms.gae import compute_gae
+
+
+def test_compute_gae_basic():
+    rewards = [1.0, 1.0, 1.0]
+    values = [0.0, 0.0, 0.0]
+    adv = compute_gae(rewards, values, gamma=1.0, lam=1.0)
+    assert np.allclose(adv, [3.0, 2.0, 1.0])


### PR DESCRIPTION
## Summary
- add `compute_gae` utility for generalized advantage estimation
- export new helper from algorithms package
- provide unit test for `compute_gae`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857b1bf26588330b7079d184636dcef