### PR TITLE
Log PPO loss per epoch

### DIFF
--- a/train_selfplay.py
+++ b/train_selfplay.py
@@ -158,6 +158,7 @@ def main(
 
         for i in range(ppo_epochs):
             loss = agent0.update(batch)
+            logger.info("Episode %d epoch %d loss %.4f", ep + 1, i + 1, loss)
             if writer:
                 writer.add_scalar("loss", loss, ep * ppo_epochs + i)
 


### PR DESCRIPTION
## Summary
- log loss returned by `agent0.update()` each epoch in `train_selfplay.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857e0b918b88330b80d5f6e4062d5e1