### PR TITLE
Improve logging for debugging invalid actions

### DIFF
--- a/src/action/action_helper.py
+++ b/src/action/action_helper.py
@@ -159,8 +159,11 @@ def action_index_to_order_from_mapping(
 
     if action_index not in mapping:
         logger.error(
-            "Invalid or unavailable action index: %s. Available: %s",
+            "Invalid or unavailable action index: %s for %s at turn %s in %s. Available: %s",
             action_index,
+            getattr(player, 'username', '?'),
+            getattr(battle, 'turn', '?'),
+            getattr(battle, 'battle_tag', '?'),
             mapping,
         )
         raise ValueError(

--- a/src/env/pokemon_env.py
+++ b/src/env/pokemon_env.py
@@ -201,6 +201,7 @@ class PokemonEnv(gym.Env):
         self._battle_queues = {agent_id: asyncio.Queue() for agent_id in self.agent_ids}
         self._need_action = {agent_id: True for agent_id in self.agent_ids}
         self._action_mappings = {agent_id: {} for agent_id in self.agent_ids}
+        self._logger.debug("environment reset: cleared action queues and mappings")
 
         # poke_env は開発環境によってはインストールされていない場合があるため、
         # メソッド内で遅延インポートする。

--- a/train_selfplay.py
+++ b/train_selfplay.py
@@ -34,6 +34,7 @@ def setup_logging(log_dir: str, params: dict[str, object]) -> None:
     file_handler.setFormatter(
         logging.Formatter("%(asctime)s %(levelname)s %(message)s")
     )
+    file_handler.setLevel(logging.DEBUG)
     logging.getLogger().addHandler(file_handler)
     logging.info("Run parameters: %s", params)
 
@@ -286,8 +287,13 @@ def main(
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO, format="%(message)s")
     parser = argparse.ArgumentParser(description="Self-play PPO training script")
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default="INFO",
+        help="logging level (DEBUG, INFO, etc.)",
+    )
     parser.add_argument(
         "--config",
         type=str,
@@ -312,6 +318,8 @@ if __name__ == "__main__":
     parser.add_argument("--parallel", type=int, default=1, help="number of parallel environments")
     args = parser.parse_args()
 
+    level = getattr(logging, args.log_level.upper(), logging.INFO)
+    logging.basicConfig(level=level, format="%(message)s")
     setup_logging("logs", vars(args))
 
     main(


### PR DESCRIPTION
## Summary
- allow setting log level via `--log-level`
- log debug messages to file
- add reset debug log in environment
- include context in invalid action error

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a0dc67d588330a9d0d63adc1c895c