### PR TITLE
Store action mapping when creating mask

### DIFF
--- a/src/env/pokemon_env.py
+++ b/src/env/pokemon_env.py
@@ -166,6 +166,9 @@ class PokemonEnv(gym.Env):
                         if pkmn.species not in selected:
                             mask[idx] = 0
 
+        # 保存したマッピングを step で利用できるよう保持しておく
+        self._action_mappings[player_id] = mapping
+
         return mask, mapping
 
     def process_battle(self, battle: Any) -> int:


### PR DESCRIPTION
## Summary
- store the action mapping in `PokemonEnv.get_action_mask`
- ensure the environment retains the mapping for later `step`

## Testing
- `pytest -q`
- `pytest test/test_train_selfplay_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685a18145c848330964271be0d1b844c