### PR TITLE
Handle Struggle-only situations in mask

### DIFF
--- a/src/action/action_helper.py
+++ b/src/action/action_helper.py
@@ -119,7 +119,11 @@ def get_action_mapping(battle: Battle) -> OrderedDict[int, Tuple[str, Union[str,
         mapping[8 + i] = ("switch", i, disabled)
 
     # Struggle slot 10 (enabled only when no other moves are usable)
-    mapping[10] = ("move", "struggle", True)
+    only_struggle = (
+        len(battle.available_moves) == 1
+        and getattr(battle.available_moves[0], "id", "") == "struggle"
+    )
+    mapping[10] = ("move", "struggle", not only_struggle)
 
     return mapping
 

--- a/test/test_disabled_move.py
+++ b/test/test_disabled_move.py
@@ -122,3 +122,26 @@ def test_pp0_move_disabled_and_mask():
     mask = env._build_action_mask(mapping)
     assert len(mask) == len(mapping)
     assert mask[0] == 0
+
+
+class StruggleBattle:
+    def __init__(self):
+        m0 = SimpleNamespace(id="a", current_pp=0)
+        m1 = SimpleNamespace(id="b", current_pp=0)
+        m2 = SimpleNamespace(id="c", current_pp=0)
+        m3 = SimpleNamespace(id="d", current_pp=0)
+        self.active_pokemon = SimpleNamespace(moves={0: m0, 1: m1, 2: m2, 3: m3})
+        self.available_moves = [SimpleNamespace(id="struggle", current_pp=1)]
+        self.available_switches = []
+        self.force_switch = False
+        self.can_tera = False
+
+
+def test_struggle_only_mask():
+    env = make_env()
+    battle = StruggleBattle()
+    mapping = action_helper.get_action_mapping(battle)
+    assert mapping[10] == ("move", "struggle", False)
+    mask, _ = action_helper.get_available_actions(battle)
+    assert mask[10] == 1
+    assert all(m == 0 for m in mask[:10])


### PR DESCRIPTION
## Summary
- enable struggle action when it's the only available move
- test that index 10 is active when only struggle remains

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cf1b4f3a88330a6c80147c2b47f8e