### PR TITLE
Log action mask with player identifier

### DIFF
--- a/src/agents/MapleAgent.py
+++ b/src/agents/MapleAgent.py
@@ -14,6 +14,14 @@ class MapleAgent:
         if hasattr(self.env, "register_agent"):
             self.env.register_agent(self)
 
+    def _get_player_id(self) -> str:
+        """Return the player id registered with the environment."""
+        agents = getattr(self.env, "_agents", {})
+        for pid, agent in agents.items():
+            if agent is self:
+                return pid
+        return getattr(self.env, "agent_ids", ["player"])[0]
+
     def choose_team(self, observation: Any) -> str:
         """Return a team selection string for the team preview phase.
 
@@ -52,7 +60,8 @@ class MapleAgent:
             valid_indices = [i for i, flag in enumerate(action_mask) if flag]
         except Exception:
             valid_indices = []
-        print(f"{self.__class__.__name__}: available mask = {action_mask}")
+        player_id = self._get_player_id()
+        print(f"{player_id}: {action_mask}")
         if valid_indices:
             action_idx = int(self.env.rng.choice(valid_indices))
         else:

--- a/src/agents/RLAgent.py
+++ b/src/agents/RLAgent.py
@@ -47,7 +47,8 @@ class RLAgent(MapleAgent):
     def act(self, observation: np.ndarray, action_mask: np.ndarray) -> int:
         """Sample an action index according to the policy."""
         # Show the received mask to make debugging of invalid actions easier
-        self._logger.debug("%s: available mask = %s", self.__class__.__name__, action_mask)
+        player_id = self._get_player_id()
+        self._logger.debug("%s: %s", player_id, action_mask)
         probs = self.select_action(observation, action_mask)
         rng = getattr(self.env, "rng", np.random.default_rng())
         action = int(rng.choice(len(probs), p=probs))


### PR DESCRIPTION
## Summary
- show player id when logging action masks in `MapleAgent`
- use the same helper in `RLAgent` to log received masks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d68e716c48330b99ba8ccbb43e2d5