### PR TITLE
Fix player_id retrieval for logging

### DIFF
--- a/src/agents/MapleAgent.py
+++ b/src/agents/MapleAgent.py
@@ -16,9 +16,16 @@ class MapleAgent:
 
     def _get_player_id(self) -> str:
         """Return the player id registered with the environment."""
+        # ``register_agent`` stores the id on the agent itself which allows
+        # quick retrieval without relying on the environment's internal mapping.
+        if hasattr(self, "_player_id"):
+            return getattr(self, "_player_id")
+
         agents = getattr(self.env, "_agents", {})
         for pid, agent in agents.items():
             if agent is self:
+                # Cache for future calls
+                setattr(self, "_player_id", pid)
                 return pid
         return getattr(self.env, "agent_ids", ["player"])[0]
 

--- a/src/env/pokemon_env.py
+++ b/src/env/pokemon_env.py
@@ -133,6 +133,13 @@ class PokemonEnv(gym.Env):
         if not hasattr(self, "_agents"):
             self._agents: dict[str, Any] = {}
         self._agents[player_id] = agent
+        # Also store the identifier on the agent itself so that it can
+        # reliably know which player it controls even if the internal mapping
+        # is later overwritten.
+        try:
+            setattr(agent, "_player_id", player_id)
+        except Exception:  # pragma: no cover - ignore if attribute cannot be set
+            pass
 
     def get_current_battle(self, agent_id: str = "player_0") -> Any | None:
         """Return the latest :class:`Battle` object for ``agent_id``."""


### PR DESCRIPTION
## Summary
- ensure player id is stored on agents when registered
- cache id in MapleAgent for reliable log output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ddc454550833089450e277ec4b2f9