### PR TITLE
Implement PPO model save/load

### DIFF
--- a/docs/train_usage.md
+++ b/docs/train_usage.md
@@ -12,7 +12,7 @@ python train_selfplay.py [オプション]
 |------------|------|
 | `--config FILE` | 設定ファイルのパスを指定します（既定: `config/train_config.yml`） |
 | `--episodes N` | 実行するエピソード数を指定します |
-| `--save FILE` | 学習後のモデルを保存するファイルパス |
+| `--save FILE` | 学習後のモデルを保存するファイルパス。保存されるファイルには方策ネットワークと価値ネットワーク両方の重みが含まれます |
 | `--tensorboard` | TensorBoard ログを有効にします |
 | `--ppo-epochs N` | 1 エピソード終了後の PPO 更新回数 |
 | `--clip R` | PPO のクリップ率を指定します |

--- a/evaluate_rl.py
+++ b/evaluate_rl.py
@@ -126,7 +126,11 @@ def evaluate_single(
     policy_net = PolicyNetwork(env.observation_space, env.action_space)
     value_net = ValueNetwork(env.observation_space)
     state_dict = torch.load(model_path, map_location="cpu")
-    policy_net.load_state_dict(state_dict)
+    if isinstance(state_dict, dict) and "policy" in state_dict and "value" in state_dict:
+        policy_net.load_state_dict(state_dict["policy"])
+        value_net.load_state_dict(state_dict["value"])
+    else:
+        policy_net.load_state_dict(state_dict)
     params = list(policy_net.parameters()) + list(value_net.parameters())
     optimizer = optim.Adam(params, lr=1e-3)
     agent = RLAgent(env, policy_net, value_net, optimizer)
@@ -160,7 +164,11 @@ def compare_models(
     )
     value1 = ValueNetwork(env.observation_space[env.agent_ids[1]])
     state_dict1 = torch.load(model_b, map_location="cpu")
-    policy1.load_state_dict(state_dict1)
+    if isinstance(state_dict1, dict) and "policy" in state_dict1 and "value" in state_dict1:
+        policy1.load_state_dict(state_dict1["policy"])
+        value1.load_state_dict(state_dict1["value"])
+    else:
+        policy1.load_state_dict(state_dict1)
     params1 = list(policy1.parameters()) + list(value1.parameters())
     opt1 = optim.Adam(params1, lr=1e-3)
     agent1 = RLAgent(env, policy1, value1, opt1)
@@ -171,7 +179,11 @@ def compare_models(
     )
     value0 = ValueNetwork(env.observation_space[env.agent_ids[0]])
     state_dict0 = torch.load(model_a, map_location="cpu")
-    policy0.load_state_dict(state_dict0)
+    if isinstance(state_dict0, dict) and "policy" in state_dict0 and "value" in state_dict0:
+        policy0.load_state_dict(state_dict0["policy"])
+        value0.load_state_dict(state_dict0["value"])
+    else:
+        policy0.load_state_dict(state_dict0)
     params0 = list(policy0.parameters()) + list(value0.parameters())
     opt0 = optim.Adam(params0, lr=1e-3)
     agent0 = RLAgent(env, policy0, value0, opt0)

--- a/test/run_battle.py
+++ b/test/run_battle.py
@@ -65,7 +65,11 @@ def run_single_battle(model_path: str | None = None) -> dict:
         )
         value = ValueNetwork(env.observation_space[env.agent_ids[0]])
         state_dict = torch.load(model_path, map_location="cpu")
-        policy.load_state_dict(state_dict)
+        if isinstance(state_dict, dict) and "policy" in state_dict and "value" in state_dict:
+            policy.load_state_dict(state_dict["policy"])
+            value.load_state_dict(state_dict["value"])
+        else:
+            policy.load_state_dict(state_dict)
         params = list(policy.parameters()) + list(value.parameters())
         optimizer = optim.Adam(params, lr=1e-3)
         agent0 = RLAgent(env, policy, value, optimizer)

--- a/train_selfplay.py
+++ b/train_selfplay.py
@@ -275,7 +275,13 @@ def main(
             try:
                 ckpt_dir.mkdir(parents=True, exist_ok=True)
                 ckpt_path = ckpt_dir / f"checkpoint_ep{ep + 1}.pt"
-                torch.save(policy_net.state_dict(), ckpt_path)
+                torch.save(
+                    {
+                        "policy": policy_net.state_dict(),
+                        "value": value_net.state_dict(),
+                    },
+                    ckpt_path,
+                )
                 logger.info("Checkpoint saved to %s", ckpt_path)
             except OSError as exc:
                 logger.error("Failed to save checkpoint: %s", exc)
@@ -295,7 +301,13 @@ def main(
         path = Path(save_path)
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
-            torch.save(policy_net.state_dict(), path)
+            torch.save(
+                {
+                    "policy": policy_net.state_dict(),
+                    "value": value_net.state_dict(),
+                },
+                path,
+            )
             logger.info("Model saved to %s", path)
         except OSError as exc:
             logger.error("Failed to save model: %s", exc)


### PR DESCRIPTION
## Summary
- extend `train_selfplay.py` to save policy and value networks together
- load new format in `evaluate_rl.py` and CLI utilities
- document that saved models contain both networks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860ae525894833084f72108768b09c2