### PR TITLE
Implement algorithm choice in self-play training

### DIFF
--- a/config/train_config.yml
+++ b/config/train_config.yml
@@ -8,3 +8,4 @@ clip_range: 0.0
 value_coef: 0.0
 entropy_coef: 0.0
 ppo_epochs: 1
+algorithm: ppo

--- a/docs/train_usage.md
+++ b/docs/train_usage.md
@@ -14,6 +14,7 @@ python train_selfplay.py [オプション]
 | `--episodes N` | 実行するエピソード数を指定します |
 | `--save FILE` | 学習後のモデルを保存するファイルパス。保存されるファイルには方策ネットワークと価値ネットワーク両方の重みが含まれます |
 | `--tensorboard` | TensorBoard ログを有効にします |
+| `--algo {reinforce,ppo}` | 使用するアルゴリズムを選択します |
 | `--ppo-epochs N` | 1 エピソード終了後の PPO 更新回数 |
 | `--clip R` | PPO のクリップ率を指定します |
 | `--gae-lambda L` | GAE における λ パラメータ |
@@ -21,7 +22,7 @@ python train_selfplay.py [オプション]
 例:
 
 ```bash
-python train_selfplay.py --episodes 100 --clip 0.2 --gae-lambda 0.95 --save model.pt
+python train_selfplay.py --episodes 100 --algo ppo --clip 0.2 --gae-lambda 0.95 --save model.pt
 ```
 
 オプションを指定しない場合でも、`train_config.yml` の内容が自動的に読み込まれるため、

--- a/test/test_train_selfplay_cli.py
+++ b/test/test_train_selfplay_cli.py
@@ -120,6 +120,7 @@ sys.modules['src.agents'] = agents
 
 alg = types.ModuleType('src.algorithms')
 alg.PPOAlgorithm = lambda *a, **k: types.SimpleNamespace()
+alg.ReinforceAlgorithm = lambda *a, **k: types.SimpleNamespace()
 alg.compute_gae = lambda rewards, values, gamma=0.99, lam=1.0: [0.0] * len(rewards)
 sys.modules['src.algorithms'] = alg
 


### PR DESCRIPTION
## Summary
- support selection of training algorithm (REINFORCE or PPO)
- store selected algorithm in config
- document new `--algo` option
- adjust CLI test stubs for new import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860b9efd434833081a6f00e9fa1e616