### PR TITLE
Implement CompositeReward for weighted sub rewards

### DIFF
--- a/src/rewards/__init__.py
+++ b/src/rewards/__init__.py
@@ -19,5 +19,6 @@ class RewardBase(ABC):
 __all__ = ["RewardBase"]
 
 from .hp_delta import HPDeltaReward
+from .composite import CompositeReward
 
-__all__.append("HPDeltaReward")
+__all__.extend(["HPDeltaReward", "CompositeReward"])

--- a/src/rewards/composite.py
+++ b/src/rewards/composite.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Mapping
+
+try:  # PyYAML may not be installed in minimal environments
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - fallback when PyYAML is missing
+    yaml = None
+
+from . import RewardBase, HPDeltaReward
+
+
+class CompositeReward(RewardBase):
+    """複数のサブ報酬を合成するクラス。"""
+
+    DEFAULT_REWARDS: Mapping[str, Callable[[], RewardBase]] = {
+        "hp_delta": HPDeltaReward,
+    }
+
+    def __init__(self, config_path: str, reward_map: Mapping[str, Callable[[], RewardBase]] | None = None) -> None:
+        self.config_path = config_path
+        self.reward_map = dict(self.DEFAULT_REWARDS)
+        if reward_map is not None:
+            self.reward_map.update(reward_map)
+        self.rewards: Dict[str, RewardBase] = {}
+        self.weights: Dict[str, float] = {}
+        self.last_values: Dict[str, float] = {}
+        self._load_config()
+
+    def _load_config(self) -> None:
+        try:
+            with open(self.config_path, "r", encoding="utf-8") as f:
+                text = f.read()
+        except FileNotFoundError:
+            text = ""
+
+        if yaml is not None:
+            cfg = yaml.safe_load(text) or {}
+        else:
+            cfg = self._parse_simple_yaml(text)
+        reward_cfg = cfg.get("rewards", {})
+        for name, params in reward_cfg.items():
+            if not isinstance(params, Mapping):
+                continue
+            if not params.get("enabled", True):
+                continue
+            factory = self.reward_map.get(name)
+            if factory is None:
+                continue
+            self.rewards[name] = factory()
+            self.weights[name] = float(params.get("weight", 1.0))
+            self.last_values[name] = 0.0
+
+    def _parse_simple_yaml(self, text: str) -> Dict[str, Any]:
+        """Very small YAML parser used when PyYAML is unavailable."""
+        result: Dict[str, Any] = {}
+        current: Dict[str, Any] | None = None
+        subsection: Dict[str, Any] | None = None
+        for line in text.splitlines():
+            if not line.strip() or line.strip().startswith("#"):
+                continue
+            indent = len(line) - len(line.lstrip())
+            key, _, rest = line.strip().partition(":")
+            rest = rest.strip()
+            if indent == 0:
+                current = result.setdefault(key, {})
+                subsection = None
+            elif indent == 2 and current is not None:
+                if rest:
+                    current[key] = self._convert_value(rest)
+                    subsection = None
+                else:
+                    subsection = {}
+                    current[key] = subsection
+            elif indent == 4 and subsection is not None:
+                subsection[key] = self._convert_value(rest)
+        return result
+
+    @staticmethod
+    def _convert_value(value: str) -> Any:
+        if value.lower() == "true":
+            return True
+        if value.lower() == "false":
+            return False
+        try:
+            num = float(value)
+            return int(num) if num.is_integer() else num
+        except ValueError:
+            return value
+
+    def reset(self, battle: Any | None = None) -> None:
+        for r in self.rewards.values():
+            r.reset(battle)
+        for key in self.last_values:
+            self.last_values[key] = 0.0
+
+    def calc(self, battle: Any) -> float:
+        total = 0.0
+        for name, r in self.rewards.items():
+            value = float(r.calc(battle))
+            self.last_values[name] = value
+            total += value * self.weights.get(name, 1.0)
+        return float(total)
+
+
+__all__ = ["CompositeReward"]

--- a/tests/test_composite_reward.py
+++ b/tests/test_composite_reward.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from src.rewards import CompositeReward, RewardBase
+
+
+class ConstReward(RewardBase):
+    def __init__(self, value: float) -> None:
+        self.value = value
+        self.reset_called = False
+
+    def reset(self, battle: object | None = None) -> None:
+        self.reset_called = True
+
+    def calc(self, battle: object) -> float:
+        return float(self.value)
+
+
+def test_composite_reward(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "reward.yaml"
+    yaml_text = (
+        "rewards:\n"
+        "  a:\n"
+        "    weight: 2.0\n"
+        "    enabled: true\n"
+        "  b:\n"
+        "    weight: 0.5\n"
+        "    enabled: true\n"
+    )
+    yaml_path.write_text(yaml_text, encoding="utf-8")
+
+    comp = CompositeReward(
+        str(yaml_path),
+        reward_map={"a": lambda: ConstReward(1.0), "b": lambda: ConstReward(1.0)},
+    )
+    comp.reset(None)
+    assert all(r.reset_called for r in comp.rewards.values())
+    reward = comp.calc(None)
+    assert reward == 2.0 * 1.0 + 0.5 * 1.0
+    assert comp.last_values["a"] == 1.0
+    assert comp.last_values["b"] == 1.0


### PR DESCRIPTION
## Summary
- implement `CompositeReward` to combine multiple reward signals
- export new class from rewards package
- add unit tests for composite behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68615dc72cbc8330af07e1a35a0abff4