### PR TITLE
Add reward-config option and log sub rewards

### DIFF
--- a/docs/train_usage.md
+++ b/docs/train_usage.md
@@ -19,6 +19,7 @@ python train_selfplay.py [オプション]
 | `--clip R` | PPO のクリップ率を指定します |
 | `--gae-lambda L` | GAE における λ パラメータ |
 | `--parallel N` | 並列実行する環境数 |
+| `--reward-config FILE` | CompositeReward 用の YAML ファイルを指定 |
 
 例:
 


### PR DESCRIPTION
## Summary
- extend `train_selfplay.py` to accept `--reward-config` for composite rewards
- aggregate `_sub_reward_logs` after each episode and log per-sub-reward values
- document new command line option in `docs/train_usage.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686161ed96e8833098b4921e3d76dc75