### PR TITLE
Add KnockoutReward skeleton

### DIFF
--- a/src/rewards/__init__.py
+++ b/src/rewards/__init__.py
@@ -20,7 +20,9 @@ __all__ = [
     "RewardBase",
     "HPDeltaReward",
     "CompositeReward",
+    "KnockoutReward",
 ]
 
 from .hp_delta import HPDeltaReward
 from .composite import CompositeReward
+from .knockout import KnockoutReward

--- a/src/rewards/knockout.py
+++ b/src/rewards/knockout.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Dict, Any
+
+from . import RewardBase
+
+
+class KnockoutReward(RewardBase):
+    """撃破/被撃破に基づいて報酬を計算するクラス。"""
+
+    SELF_FAINT_COEF = -0.5
+    ENEMY_FAINT_COEF = 1.0
+
+    def __init__(self) -> None:
+        # ポケモンIDセット
+        self.my_ids: Dict[int, bool] = {}
+        self.opp_ids: Dict[int, bool] = {}
+
+        # 直前ターンのHPと生存状態
+        self.prev_my_hp: Dict[int, int] = {}
+        self.prev_opp_hp: Dict[int, int] = {}
+        self.prev_my_alive: Dict[int, bool] = {}
+        self.prev_opp_alive: Dict[int, bool] = {}
+
+        self.self_fainted = 0.0
+        self.enemy_fainted = 0.0
+
+    def reset(self, battle: Any | None = None) -> None:
+        self.my_ids.clear()
+        self.opp_ids.clear()
+        self.prev_my_hp.clear()
+        self.prev_opp_hp.clear()
+        self.prev_my_alive.clear()
+        self.prev_opp_alive.clear()
+        self.self_fainted = 0.0
+        self.enemy_fainted = 0.0
+
+        if battle is not None:
+            for mon in getattr(battle, "team", {}).values():
+                ident = id(mon)
+                self.my_ids[ident] = True
+                self.prev_my_hp[ident] = getattr(mon, "current_hp", 0) or 0
+                self.prev_my_alive[ident] = not getattr(mon, "fainted", False)
+            for mon in getattr(battle, "opponent_team", {}).values():
+                ident = id(mon)
+                self.opp_ids[ident] = True
+                self.prev_opp_hp[ident] = getattr(mon, "current_hp", 0) or 0
+                self.prev_opp_alive[ident] = not getattr(mon, "fainted", False)
+
+    def calc(self, battle: Any) -> float:  # pragma: no cover - not implemented
+        return 0.0
+
+
+__all__ = ["KnockoutReward"]

--- a/tests/test_knockout_reward.py
+++ b/tests/test_knockout_reward.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from src.rewards import KnockoutReward
+
+
+class DummyMon:
+    def __init__(self, current_hp: int, fainted: bool = False) -> None:
+        self.current_hp = current_hp
+        self.max_hp = current_hp
+        self.fainted = fainted
+
+
+class DummyBattle:
+    def __init__(self, team, opp_team) -> None:
+        self.team = {i: m for i, m in enumerate(team)}
+        self.opponent_team = {i: m for i, m in enumerate(opp_team)}
+
+
+def test_knockout_reset_initializes_state():
+    mons = [DummyMon(100), DummyMon(50)]
+    opps = [DummyMon(80)]
+    battle = DummyBattle(mons, opps)
+    r = KnockoutReward()
+    r.reset(battle)
+
+    assert set(r.my_ids.keys()) == {id(m) for m in mons}
+    assert set(r.opp_ids.keys()) == {id(m) for m in opps}
+    for m in mons:
+        assert r.prev_my_hp[id(m)] == m.current_hp
+        assert r.prev_my_alive[id(m)] is True
+    for m in opps:
+        assert r.prev_opp_hp[id(m)] == m.current_hp
+        assert r.prev_opp_alive[id(m)] is True
+
+    r.reset(None)
+    assert r.my_ids == {}
+    assert r.opp_ids == {}
+    assert r.prev_my_hp == {}


### PR DESCRIPTION
## Summary
- implement `KnockoutReward` class
- export class from rewards package
- add unit test for `KnockoutReward`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861c2862ab08330a617d61f30512792