### PR TITLE
Implement faint detection logic

### DIFF
--- a/src/rewards/knockout.py
+++ b/src/rewards/knockout.py
@@ -40,6 +40,31 @@ class KnockoutReward(RewardBase):
 
     def calc(self, battle: object) -> float:
         """報酬を計算して返す。"""
+
+        new_enemy_ko = 0
+        new_self_ko = 0
+
+        for mon in getattr(battle, "team", {}).values():
+            cur_hp = getattr(mon, "current_hp", 0) or 0
+            fainted = getattr(mon, "fainted", False)
+            prev_alive = self.prev_my_alive.get(id(mon), not fainted)
+            if fainted and prev_alive:
+                new_self_ko += 1
+            self.prev_my_hp[id(mon)] = cur_hp
+            self.prev_my_alive[id(mon)] = not fainted
+
+        for mon in getattr(battle, "opponent_team", {}).values():
+            cur_hp = getattr(mon, "current_hp", 0) or 0
+            fainted = getattr(mon, "fainted", False)
+            prev_alive = self.prev_opp_alive.get(id(mon), not fainted)
+            if fainted and prev_alive:
+                new_enemy_ko += 1
+            self.prev_opp_hp[id(mon)] = cur_hp
+            self.prev_opp_alive[id(mon)] = not fainted
+
+        self.enemy_ko += new_enemy_ko
+        self.self_ko += new_self_ko
+
         return 0.0
 
 

--- a/tests/test_knockout_reward.py
+++ b/tests/test_knockout_reward.py
@@ -37,3 +37,30 @@ def test_knockout_reset_records_initial_state():
     assert r.prev_opp_alive[id(opp1)] is True
     assert r.enemy_ko == 0
     assert r.self_ko == 0
+
+
+def test_knockout_calc_counts_new_faints():
+    my1 = DummyMon(50, False)
+    my2 = DummyMon(40, False)
+    opp1 = DummyMon(60, False)
+    battle = DummyBattle([my1, my2], [opp1])
+
+    r = KnockoutReward()
+    r.reset(battle)
+
+    my1.current_hp = 0
+    my1.fainted = True
+    opp1.current_hp = 0
+    opp1.fainted = True
+
+    reward = r.calc(battle)
+
+    assert reward == 0.0
+    assert r.self_ko == 1
+    assert r.enemy_ko == 1
+
+    # Calling again without additional faint should not change counts
+    reward2 = r.calc(battle)
+    assert reward2 == 0.0
+    assert r.self_ko == 1
+    assert r.enemy_ko == 1


### PR DESCRIPTION
## Summary
- implement detection of new fainted Pokémon in `KnockoutReward.calc`
- unit test detection logic for `KnockoutReward`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68620708c42c8330868be41fe358c87e