### PR TITLE
Implement knockout reward calc

### DIFF
--- a/src/rewards/__init__.py
+++ b/src/rewards/__init__.py
@@ -20,7 +20,9 @@ __all__ = [
     "RewardBase",
     "HPDeltaReward",
     "CompositeReward",
+    "KnockoutReward",
 ]
 
 from .hp_delta import HPDeltaReward
 from .composite import CompositeReward
+from .knockout import KnockoutReward

--- a/src/rewards/knockout.py
+++ b/src/rewards/knockout.py
@@ -20,11 +20,47 @@ class KnockoutReward(RewardBase):
 
     def reset(self, battle: object | None = None) -> None:
         """内部状態をリセットする。"""
-        pass
+        self.prev_my_hp.clear()
+        self.prev_opp_hp.clear()
+        self.prev_my_alive.clear()
+        self.prev_opp_alive.clear()
+
+        if battle is not None:
+            for mon in getattr(battle, "team", {}).values():
+                self.prev_my_hp[id(mon)] = getattr(mon, "current_hp", 0) or 0
+                self.prev_my_alive[id(mon)] = not getattr(mon, "fainted", False)
+            for mon in getattr(battle, "opponent_team", {}).values():
+                self.prev_opp_hp[id(mon)] = getattr(mon, "current_hp", 0) or 0
+                self.prev_opp_alive[id(mon)] = not getattr(mon, "fainted", False)
 
     def calc(self, battle: object) -> float:
         """報酬を計算して返す。"""
-        return 0.0
+        enemy_kos = 0
+        self_kos = 0
+
+        for mon in getattr(battle, "team", {}).values():
+            cur_hp = getattr(mon, "current_hp", 0) or 0
+            alive = not getattr(mon, "fainted", cur_hp <= 0)
+            prev_alive = self.prev_my_alive.get(id(mon), alive)
+            if prev_alive and not alive:
+                self_kos += 1
+            self.prev_my_hp[id(mon)] = cur_hp
+            self.prev_my_alive[id(mon)] = alive
+
+        for mon in getattr(battle, "opponent_team", {}).values():
+            cur_hp = getattr(mon, "current_hp", 0) or 0
+            alive = not getattr(mon, "fainted", cur_hp <= 0)
+            prev_alive = self.prev_opp_alive.get(id(mon), alive)
+            if prev_alive and not alive:
+                enemy_kos += 1
+            self.prev_opp_hp[id(mon)] = cur_hp
+            self.prev_opp_alive[id(mon)] = alive
+
+        reward = (
+            enemy_kos * self.ENEMY_KO_BONUS
+            + self_kos * self.SELF_KO_PENALTY
+        )
+        return float(reward)
 
 
 __all__ = ["KnockoutReward"]

--- a/tests/test_knockout_reward.py
+++ b/tests/test_knockout_reward.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from src.rewards import KnockoutReward
+
+
+class DummyMon:
+    def __init__(self, fainted=False):
+        self.fainted = fainted
+        self.current_hp = 100
+
+
+class DummyBattle:
+    def __init__(self, my_mons, opp_mons):
+        self.team = {i: m for i, m in enumerate(my_mons)}
+        self.opponent_team = {i: m for i, m in enumerate(opp_mons)}
+        self.finished = False
+        self.won = False
+
+
+def test_knockout_enemy_ko_reward():
+    battle = DummyBattle([DummyMon(False)], [DummyMon(False)])
+    r = KnockoutReward()
+    r.reset(battle)
+    battle.opponent_team[0].fainted = True
+    assert r.calc(battle) == r.ENEMY_KO_BONUS
+
+
+def test_knockout_self_ko_penalty():
+    battle = DummyBattle([DummyMon(False)], [DummyMon(False)])
+    r = KnockoutReward()
+    r.reset(battle)
+    battle.team[0].fainted = True
+    assert r.calc(battle) == r.SELF_KO_PENALTY


### PR DESCRIPTION
## Summary
- finish KnockoutReward by tracking faint events and assigning bonuses/penalties
- expose KnockoutReward from the reward package
- add tests covering enemy and self knockouts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862096287008330980f8ae7bba7ee19