### PR TITLE
Register knockout reward in composite map

### DIFF
--- a/src/rewards/composite.py
+++ b/src/rewards/composite.py
@@ -8,6 +8,7 @@ except Exception:  # pragma: no cover - fallback when PyYAML is missing
     yaml = None
 
 from . import RewardBase, HPDeltaReward
+from .knockout import KnockoutReward
 
 
 class CompositeReward(RewardBase):
@@ -15,6 +16,7 @@ class CompositeReward(RewardBase):
 
     DEFAULT_REWARDS: Mapping[str, Callable[[], RewardBase]] = {
         "hp_delta": HPDeltaReward,
+        "knockout": KnockoutReward,
     }
 
     def __init__(self, config_path: str, reward_map: Mapping[str, Callable[[], RewardBase]] | None = None) -> None:


### PR DESCRIPTION
## Summary
- add `KnockoutReward` to the list of default rewards in `CompositeReward`
- import `KnockoutReward` directly to avoid circular import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68623a2fb18c8330bc7d117e47fcfa1a