### PR TITLE
Add constant turn penalty reward

### DIFF
--- a/src/rewards/turn_penalty.py
+++ b/src/rewards/turn_penalty.py
@@ -16,7 +16,12 @@ class TurnPenaltyReward(RewardBase):
 
     def __call__(self, battle: object) -> float:
         """報酬を計算して返す。"""
-        return 0.0
+        self.turn_count += 1
+        return float(self.penalty)
+
+    def calc(self, battle: object) -> float:  # pragma: no cover - thin wrapper
+        """Alias for compatibility with :class:`RewardBase`."""
+        return self.__call__(battle)
 
 
 __all__ = ["TurnPenaltyReward"]

--- a/tests/test_turn_penalty_reward.py
+++ b/tests/test_turn_penalty_reward.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from src.rewards import TurnPenaltyReward
+
+
+def test_turn_penalty_returns_constant_value():
+    r = TurnPenaltyReward(penalty=-0.1)
+    r.reset(None)
+    assert r(None) == -0.1
+    assert r(None) == -0.1
+    assert r.turn_count == 2
+    assert r.calc(None) == -0.1


### PR DESCRIPTION
## Summary
- R-7 実装として毎ターン一定ペナルティを返す `TurnPenaltyReward` を実装
- 同報酬のユニットテスト追加

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68632821cf308330bd5211ed742fa6c7