### PR TITLE
Implement per-turn reward penalty

### DIFF
--- a/src/rewards/composite.py
+++ b/src/rewards/composite.py
@@ -9,6 +9,7 @@ except Exception:  # pragma: no cover - fallback when PyYAML is missing
 
 from . import RewardBase, HPDeltaReward
 from .knockout import KnockoutReward
+from .turn_penalty import TurnPenaltyReward
 
 
 class CompositeReward(RewardBase):
@@ -17,6 +18,7 @@ class CompositeReward(RewardBase):
     DEFAULT_REWARDS: Mapping[str, Callable[[], RewardBase]] = {
         "hp_delta": HPDeltaReward,
         "knockout": KnockoutReward,
+        "turn_penalty": TurnPenaltyReward,
     }
 
     def __init__(self, config_path: str, reward_map: Mapping[str, Callable[[], RewardBase]] | None = None) -> None:

--- a/src/rewards/turn_penalty.py
+++ b/src/rewards/turn_penalty.py
@@ -9,15 +9,30 @@ class TurnPenaltyReward(RewardBase):
     def __init__(self, penalty: float = -0.01) -> None:
         self.penalty = penalty
         self.turn_count = 0
+        self._last_turn: int | None = None
 
     def reset(self, battle: object | None = None) -> None:
         """内部状態をリセットする。"""
         self.turn_count = 0
+        if battle is not None:
+            self._last_turn = getattr(battle, "turn", 0) - 1
+        else:
+            self._last_turn = None
 
     def __call__(self, battle: object) -> float:
         """報酬を計算して返す。"""
-        self.turn_count += 1
-        return float(self.penalty)
+        current_turn = getattr(battle, "turn", None)
+        if current_turn is None or self._last_turn is None:
+            self.turn_count += 1
+            self._last_turn = current_turn
+            return float(self.penalty)
+
+        if current_turn > self._last_turn:
+            self.turn_count += 1
+            self._last_turn = current_turn
+            return float(self.penalty)
+        self._last_turn = current_turn
+        return 0.0
 
     def calc(self, battle: object) -> float:  # pragma: no cover - thin wrapper
         """Alias for compatibility with :class:`RewardBase`."""

--- a/tests/test_turn_penalty_reward.py
+++ b/tests/test_turn_penalty_reward.py
@@ -8,10 +8,22 @@ if str(ROOT_DIR) not in sys.path:
 from src.rewards import TurnPenaltyReward
 
 
-def test_turn_penalty_returns_constant_value():
+class DummyBattle:
+    def __init__(self, turn: int) -> None:
+        self.turn = turn
+
+
+def test_turn_penalty_per_turn():
+    battle = DummyBattle(turn=1)
     r = TurnPenaltyReward(penalty=-0.1)
-    r.reset(None)
-    assert r(None) == -0.1
-    assert r(None) == -0.1
+    r.reset(battle)
+
+    assert r(battle) == -0.1
+    # 同じターン内ではペナルティは重複しない
+    assert r(battle) == 0.0
+
+    battle.turn = 2
+    assert r(battle) == -0.1
     assert r.turn_count == 2
-    assert r.calc(None) == -0.1
+    # calc も同一のロジックを通る
+    assert r.calc(battle) == 0.0


### PR DESCRIPTION
## Summary
- apply penalty once per battle turn
- expose new reward in `CompositeReward`
- test per-turn behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68634589fa9c833090b3a3a75270363f