### PR TITLE
Default to composite reward

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ PokemonEnv を利用したポケモンバトル強化学習フレームワーク
   `PokemonEnv` の行動マスクと連携するよう更新
 - 2025-07-01 PPO 対応手順をまとめた `docs/M7_setup.md` を追加し、`train_selfplay.py` の `--algo` オプションでアルゴリズムを切り替え可能に
 - 2025-07-05 `HPDeltaReward` を追加し、`--reward hp_delta` オプションで使用可能に
+- 2025-07-06 `train_selfplay.py` の報酬を `CompositeReward` ベースに変更し、
+  `config/train_config.yml` の設定で他の報酬へ切り替え可能に

--- a/config/train_config.yml
+++ b/config/train_config.yml
@@ -9,3 +9,5 @@ value_coef: 0.6
 entropy_coef: 0.02
 ppo_epochs: 4
 algorithm: ppo
+reward: composite
+reward_config: config/reward.yaml

--- a/docs/train_usage.md
+++ b/docs/train_usage.md
@@ -19,7 +19,8 @@ python train_selfplay.py [オプション]
 | `--clip R` | PPO のクリップ率を指定します |
 | `--gae-lambda L` | GAE における λ パラメータ |
 | `--parallel N` | 並列実行する環境数 |
-| `--reward-config FILE` | CompositeReward 用の YAML ファイルを指定 |
+| `--reward STR` | 使用する報酬タイプを指定します（既定: `composite`） |
+| `--reward-config FILE` | CompositeReward 用の YAML ファイルを指定（既定: `config/reward.yaml`） |
 
 例:
 
@@ -36,6 +37,8 @@ python train_selfplay.py \
 
 オプションを指定しない場合でも、`train_config.yml` の内容が自動的に読み込まれるため、
 最小限の入力で学習を開始できます。
+デフォルトでは `CompositeReward` が使用されており、
+`config/reward.yaml` の各項目を編集することで簡単に報酬の重みを調整できます。
 
 ## Knockout 報酬の使用例
 

--- a/src/env/pokemon_env.py
+++ b/src/env/pokemon_env.py
@@ -33,7 +33,7 @@ class PokemonEnv(gym.Env):
         *,
         seed: int | None = None,
         save_replays: bool | str = False,
-        reward: str = "hp_delta",
+        reward: str = "composite",
         reward_config_path: str | None = None,
         **kwargs: Any,
     ) -> None:

--- a/train_selfplay.py
+++ b/train_selfplay.py
@@ -64,7 +64,7 @@ from src.agents import PolicyNetwork, ValueNetwork, RLAgent  # noqa: E402
 from src.algorithms import PPOAlgorithm, ReinforceAlgorithm, compute_gae  # noqa: E402
 
 
-def init_env(reward: str = "hp_delta", reward_config: str | None = None) -> PokemonEnv:
+def init_env(reward: str = "composite", reward_config: str | None = None) -> PokemonEnv:
     """Create :class:`PokemonEnv` for self-play."""
     observer = StateObserver(str(ROOT_DIR / "config" / "state_spec.yml"))
     env = PokemonEnv(
@@ -199,8 +199,8 @@ def main(
     checkpoint_interval: int = 0,
     checkpoint_dir: str = "checkpoints",
     algo: str = "ppo",
-    reward: str = "hp_delta",
-    reward_config: str | None = None,
+    reward: str = "composite",
+    reward_config: str | None = str(ROOT_DIR / "config" / "reward.yaml"),
 ) -> None:
     """Entry point for self-play PPO training.
 
@@ -222,6 +222,10 @@ def main(
     value_coef = float(cfg.get("value_coef", value_coef))
     entropy_coef = float(cfg.get("entropy_coef", entropy_coef))
     algo_name = str(cfg.get("algorithm", algo)).lower()
+    reward = str(cfg.get("reward", reward))
+    reward_config = cfg.get("reward_config", reward_config)
+    if reward_config is not None:
+        reward_config = str(reward_config)
 
     writer = SummaryWriter() if tensorboard else None
 
@@ -420,12 +424,13 @@ if __name__ == "__main__":
     parser.add_argument(
         "--reward",
         type=str,
-        default="hp_delta",
-        help="reward function to use (hp_delta)",
+        default="composite",
+        help="reward function to use (composite)",
     )
     parser.add_argument(
         "--reward-config",
         type=str,
+        default=str(ROOT_DIR / "config" / "reward.yaml"),
         help="path to composite reward YAML file",
     )
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- default reward function to composite mode
- add reward configuration support in `train_config.yml`
- document the new default reward and usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6864b25133408330a8b8dd9cd4e3d937